### PR TITLE
Added "Crits On" attribute

### DIFF
--- a/data/moves.json
+++ b/data/moves.json
@@ -1,5 +1,5 @@
-{  
-   "Attack Order":{  
+{
+   "Attack Order":{
       "Type":"Bug",
       "Freq":"EOT",
       "AC":"2",
@@ -11,7 +11,7 @@
       "Contest Effect":"Incentives",
       "Crits On":18
    },
-   "Bug Bite":{  
+   "Bug Bite":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"2",
@@ -23,7 +23,7 @@
       "Contest Effect":"Attention Grabber",
       "Crits On":20
    },
-   "Bug Buzz":{  
+   "Bug Buzz":{
       "Type":"Bug",
       "Freq":"Scene x2",
       "AC":"2",
@@ -35,16 +35,16 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Defend Order":{  
+   "Defend Order":{
       "Type":"Bug",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Defense and Special Defense by +1 CS each.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Fell Stinger":{  
+   "Fell Stinger":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"2",
@@ -56,7 +56,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Fury Cutter":{  
+   "Fury Cutter":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"3",
@@ -68,16 +68,16 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Heal Order":{  
+   "Heal Order":{
       "Type":"Bug",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Infestation":{  
+   "Infestation":{
       "Type":"Bug",
       "Freq":"Scene x2",
       "AC":"4",
@@ -89,7 +89,7 @@
       "Contest Effect":"Gamble",
       "Crits On":20
    },
-   "Leech Life":{  
+   "Leech Life":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"2",
@@ -101,7 +101,7 @@
       "Contest Effect":"Good Show!",
       "Crits On":20
    },
-   "Megahorn":{  
+   "Megahorn":{
       "Type":"Bug",
       "Freq":"Scene x2",
       "AC":"5",
@@ -113,7 +113,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Pin Missile":{  
+   "Pin Missile":{
       "Type":"Bug",
       "Freq":"EOT",
       "AC":"4",
@@ -124,34 +124,34 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Powder":{  
+   "Powder":{
       "Type":"Bug",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"6, 1 Target, Interrupt, Powder",
       "Effect":"The target is dusted with a Coat of flammable powder. If the affected target uses a damaging Fire-Type attack, the attack is negated and instead creates a Blast 3 centered on itself as the powder explodes, and the Coat is removed. All legal targets within the Blast take damage equal to what the user of the Fire-Type attack would roll for the damage of their attack. This damage is Typeless or Fire-Type, whichever would be more effective.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Quiver Dance":{  
+   "Quiver Dance":{
       "Type":"Bug",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Special Attack, Special Defense, and Speed by +1 CS each.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Rage Powder":{  
+   "Rage Powder":{
       "Type":"Bug",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Burst 1 or Line 6; Powder",
       "Effect":"All legal targets hit by Rage Powder are Enraged. While enraged, they must shift to target the user when using a Move or Attack if the user is within reach. If the user is Fainted or Switched out, all legal targets hit by Rage Powder are no longer Enraged.",
       "Contest Type":"Smart",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Signal Beam":{  
+   "Signal Beam":{
       "Type":"Bug",
       "Freq":"EOT",
       "AC":"2",
@@ -163,7 +163,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Silver Wind":{  
+   "Silver Wind":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"2",
@@ -175,16 +175,16 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Spider Web":{  
+   "Spider Web":{
       "Type":"Bug",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"5, 1 Target",
       "Effect":"Spider Web cannot miss. The target is Stuck and Trapped. If the target is freed of the Stuck condition, it is freed of Trapped as well. *Grants Threaded",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Steamroller":{  
+   "Steamroller":{
       "Type":"Bug",
       "Freq":"EOT",
       "AC":"2",
@@ -196,16 +196,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Sticky Web":{  
+   "Sticky Web":{
       "Type":"Bug",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"6, Hazard",
       "Effect":"Set 8 square meters of Sticky Web hazards within your range such that all 8 meters are adjacent with at least one other space of Sticky Web. Sticky Web causes Terrain to become Slow Terrain, and a grounded foe that runs into the hazard has its Speed lowered by -1 CS and becomes Slowed until the end of their next turn. Flying-type Pokémon and Pokémon and Trainers with Levitate are not affected by Sticky Web. Bug-type Pokémon may move over Sticky Web harmlessly, destroying theHazards as they do so. *Grants Threaded",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "String Shot":{  
+   "String Shot":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"3",
@@ -213,9 +213,9 @@
       "Range":"Cone 2",
       "Effect":"Lower the Speed of all legal targets by -1 CS. If this lowers their Speed CS to -6, or if their Speed CS was already at -6, they are instead Stuck. *Grants Threaded",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Struggle Bug":{  
+   "Struggle Bug":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"2",
@@ -227,16 +227,16 @@
       "Contest Effect":"Excitement",
       "Crits On":20
    },
-   "Tail Glow":{  
+   "Tail Glow":{
       "Type":"Bug",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Special Attack by +3 CS. *Grants Glow",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Twineedle":{  
+   "Twineedle":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"3",
@@ -248,7 +248,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "U-Turn":{  
+   "U-Turn":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"2",
@@ -260,7 +260,7 @@
       "Contest Effect":"Inversed Appeal",
       "Crits On":20
    },
-   "X-Scissor":{  
+   "X-Scissor":{
       "Type":"Bug",
       "Freq":"At-Will",
       "AC":"2",
@@ -271,7 +271,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Assurance":{  
+   "Assurance":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -283,7 +283,7 @@
       "Contest Effect":"Double Time",
       "Crits On":20
    },
-   "Beat Up":{  
+   "Beat Up":{
       "Type":"Dark",
       "Freq":"EOT",
       "DB":"See Effect",
@@ -294,7 +294,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Bite":{  
+   "Bite":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -306,7 +306,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Crunch":{  
+   "Crunch":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"2",
@@ -318,7 +318,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Dark Pulse":{  
+   "Dark Pulse":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"2",
@@ -330,7 +330,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Dark Void":{  
+   "Dark Void":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"4",
@@ -338,9 +338,9 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target falls Asleep. Once per Scene, Dark Void may be used as if its range were “Burst 5, Friendly” instead.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Embargo":{  
+   "Embargo":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -348,9 +348,9 @@
       "Range":"6, 1 Target",
       "Effect":"The target cannot use or benefit from held items for the remainder of the encounter. Embargo may only affect one target at a time; if Embargo is used on a new target, the previous target is freed from the effect.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Fake Tears":{  
+   "Fake Tears":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"2",
@@ -358,9 +358,9 @@
       "Range":"8, 1 Target, Social",
       "Effect":"Lower the target's Special Defense by -2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Feint Attack":{  
+   "Feint Attack":{
       "Type":"Dark",
       "Freq":"EOT",
       "DB":"6",
@@ -371,7 +371,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Flatter":{  
+   "Flatter":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -379,9 +379,9 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Raise the target's Special Attack by +1 CS. Flatter Confuses the target.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Fling":{  
+   "Fling":{
       "Type":"Dark",
       "Freq":"Scene x2",
       "AC":"2",
@@ -393,7 +393,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Foul Play":{  
+   "Foul Play":{
       "Type":"Dark",
       "Freq":"Scene x2",
       "AC":"2",
@@ -405,16 +405,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Hone Claws":{  
+   "Hone Claws":{
       "Type":"Dark",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Attack by +1 CS and Accuracy by +1.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Knock Off":{  
+   "Knock Off":{
       "Type":"Dark",
       "Freq":"Scene",
       "AC":"2",
@@ -426,25 +426,25 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Memento":{  
+   "Memento":{
       "Type":"Dark",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"8, 1 Target, Trigger, Free Action",
       "Effect":"Memento may be used as a Free Action that does not consume a Command action when the user becomes Fainted. Lower each of the target's stats by -2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show",
+      "Contest Effect":"Big Show"
    },
-   "Nasty Plot":{  
+   "Nasty Plot":{
       "Type":"Dark",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Special Attack by +2 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Night Daze":{  
+   "Night Daze":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"3",
@@ -456,7 +456,7 @@
       "Contest Effect":"Unsettling",
       "Crits On":20
    },
-   "Night Slash":{  
+   "Night Slash":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"2",
@@ -468,7 +468,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":18
    },
-   "Parting Shot":{  
+   "Parting Shot":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -476,9 +476,9 @@
       "Range":"6, 1 Target, Social",
       "Effect":"If Parting Shot successfully hits, the target's Attack and Special Attack stats are lowered by one CS and the user is immediately recalled in the same turn. A new Pokémon may immediately be sent out. using Parting Shot lets a Trapped user be recalled.",
       "Contest Type":"Smart",
-      "Contest Effect":"Catching Up",
+      "Contest Effect":"Catching Up"
    },
-   "Payback":{  
+   "Payback":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"2",
@@ -490,7 +490,7 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Punishment":{  
+   "Punishment":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"2",
@@ -502,7 +502,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Pursuit":{  
+   "Pursuit":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -514,7 +514,7 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Quash":{  
+   "Quash":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -522,9 +522,9 @@
       "Range":"10, 1 Target, Social",
       "Effect":"Change the target's Initiative to 0 for the remainder of the round.",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace",
+      "Contest Effect":"Saving Grace"
    },
-   "Snarl":{  
+   "Snarl":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"3",
@@ -536,16 +536,16 @@
       "Contest Effect":"Excitement",
       "Crits On":20
    },
-   "Snatch":{  
+   "Snatch":{
       "Type":"Dark",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"6, 1 Target, Trigger, Interrupt",
       "Effect":"If the target uses a Self-Targeting Move, you may use Snatch as an Interrupt. You gain the benefits of the Self-Targeting Move instead of the target.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Sucker Punch":{  
+   "Sucker Punch":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -557,7 +557,7 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Switcheroo":{  
+   "Switcheroo":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -565,9 +565,9 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user and the target exchange held items.",
       "Contest Type":"Cool",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Taunt":{  
+   "Taunt":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"3",
@@ -575,9 +575,9 @@
       "Range":"6, 1 Target, Social",
       "Effect":"The target becomes Enraged.",
       "Contest Type":"Smart",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Thief":{  
+   "Thief":{
       "Type":"Dark",
       "Freq":"At-Will",
       "AC":"2",
@@ -589,7 +589,7 @@
       "Contest Effect":"Attention Grabber",
       "Crits On":20
    },
-   "Topsy-Turvy":{  
+   "Topsy-Turvy":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"4",
@@ -597,9 +597,9 @@
       "Range":"6, 1 Target",
       "Effect":"The target’s Combat Stages are inverted; +1 Stage becomes -1 Stage, -3 Stages becomes +3 Stages, etc.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Torment":{  
+   "Torment":{
       "Type":"Dark",
       "Freq":"Scene x2",
       "AC":"2",
@@ -607,9 +607,9 @@
       "Range":"10, 1 Target, Social",
       "Effect":"The target becomes Suppressed.",
       "Contest Type":"Tough",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Draco Meteor":{  
+   "Draco Meteor":{
       "Type":"Dragon",
       "Freq":"Scene",
       "AC":"4",
@@ -621,7 +621,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Dragon Claw":{  
+   "Dragon Claw":{
       "Type":"Dragon",
       "Freq":"At-Will",
       "AC":"2",
@@ -632,16 +632,16 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Dragon Dance":{  
+   "Dragon Dance":{
       "Type":"Dragon",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Speed by +1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Dragon Pulse":{  
+   "Dragon Pulse":{
       "Type":"Dragon",
       "Freq":"EOT",
       "AC":"2",
@@ -652,7 +652,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Dragon Rage":{  
+   "Dragon Rage":{
       "Type":"Dragon",
       "Freq":"At-Will",
       "AC":"2",
@@ -664,7 +664,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Dragon Rush":{  
+   "Dragon Rush":{
       "Type":"Dragon",
       "Freq":"Scene x2",
       "AC":"4",
@@ -676,7 +676,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Dragon Tail":{  
+   "Dragon Tail":{
       "Type":"Dragon",
       "Freq":"At-Will",
       "AC":"3",
@@ -688,7 +688,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Dragon Breath":{  
+   "Dragon Breath":{
       "Type":"Dragon",
       "Freq":"EOT",
       "AC":"2",
@@ -700,7 +700,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Dual Chop":{  
+   "Dual Chop":{
       "Type":"Dragon",
       "Freq":"EOT",
       "AC":"3",
@@ -711,7 +711,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Outrage":{  
+   "Outrage":{
       "Type":"Dragon",
       "Freq":"Scene x2",
       "AC":"3",
@@ -723,7 +723,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Roar of Time":{  
+   "Roar of Time":{
       "Type":"Dragon",
       "Freq":"Daily x2",
       "AC":"4",
@@ -735,7 +735,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Spacial Rend":{  
+   "Spacial Rend":{
       "Type":"Dragon",
       "Freq":"Daily x2",
       "AC":"3",
@@ -747,7 +747,7 @@
       "Contest Effect":"Incentives",
       "Crits On":"Even"
    },
-   "Twister":{  
+   "Twister":{
       "Type":"Dragon",
       "Freq":"At-Will",
       "AC":"2",
@@ -759,7 +759,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Bolt Strike":{  
+   "Bolt Strike":{
       "Type":"Electric",
       "Freq":"Scene x2",
       "AC":"5",
@@ -771,16 +771,16 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Charge":{  
+   "Charge":{
       "Type":"Electric",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"If the user performs an Electric Attack on its next turn, add its Damage Dice Roll an extra time to the damage. Raise the user's Special Defense by +1 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Charge Beam":{  
+   "Charge Beam":{
       "Type":"Electric",
       "Freq":"At-Will",
       "AC":"4",
@@ -792,7 +792,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Discharge":{  
+   "Discharge":{
       "Type":"Electric",
       "Freq":"EOT",
       "AC":"2",
@@ -804,7 +804,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Eerie Impulse":{  
+   "Eerie Impulse":{
       "Type":"Electric",
       "Freq":"EOT",
       "AC":"2",
@@ -812,27 +812,27 @@
       "Range":"6, 1 Target",
       "Effect":"Lower the target's Special Attack by -2 CS. *Grants Glow.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Electric Terrain":{  
+   "Electric Terrain":{
       "Type":"Electric",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"The field becomes Electrified for 5 rounds. While the field is Electrified, Pokémon and Trainers touching the ground are immune to Sleep, and Electric-Type attacks used by Pokémon and Trainers touching the ground gain a +10 Bonus to Damage Rolls.",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Electrify":{  
+   "Electrify":{
       "Type":"Electric",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"6, 1 Target.",
       "Effect":"Until the end of the user's next turn, the target's damaging Water-Type attacks and Melee attacks of any Type deal Electric-Type Damage instead of their usual Type.",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Electro Ball":{  
+   "Electro Ball":{
       "Type":"Electric",
       "Freq":"Scene x2",
       "AC":"2",
@@ -844,7 +844,7 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Electroweb":{  
+   "Electroweb":{
       "Type":"Electric",
       "Freq":"EOT",
       "AC":"3",
@@ -856,7 +856,7 @@
       "Contest Effect":"Sabotage",
       "Crits On":20
    },
-   "Fusion Bolt":{  
+   "Fusion Bolt":{
       "Type":"Electric",
       "Freq":"Scene x2",
       "AC":"2",
@@ -868,34 +868,34 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Ion Deluge":{  
+   "Ion Deluge":{
       "Type":"Electric",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"5, Ranged Blast 3, Interrupt",
       "Effect":"An ion cloud is dispersed in the targeted area. All Normal-Type Moves targeting into or originating from the area become Electric-Type Moves.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Magnet Rise":{  
+   "Magnet Rise":{
       "Type":"Electric",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self, Swift Action",
       "Effect":"The user gains the Levitate Ability for 5 turns. Magnet Rise may be activated as a Swift Action if the user is otherwise given an action that consumes a Command.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Magnetic Flux":{  
+   "Magnetic Flux":{
       "Type":"Electric",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 4",
       "Effect":"Raise the Defense and Special Defense of all legal targets with the Minus or Plus Abilities by +1 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives",
+      "Contest Effect":"Incentives"
    },
-   "Nuzzle":{  
+   "Nuzzle":{
       "Type":"Electric",
       "Freq":"Scene",
       "AC":"2",
@@ -907,7 +907,7 @@
       "Contest Effect":"Double Time",
       "Crits On":20
    },
-   "Parabolic Charge":{  
+   "Parabolic Charge":{
       "Type":"Electric",
       "Freq":"Scene",
       "AC":"4",
@@ -919,7 +919,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Shock Wave":{  
+   "Shock Wave":{
       "Type":"Electric",
       "Freq":"At-Will",
       "DB":"6",
@@ -930,7 +930,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Spark":{  
+   "Spark":{
       "Type":"Electric",
       "Freq":"EOT",
       "AC":"2",
@@ -942,7 +942,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Thunder":{  
+   "Thunder":{
       "Type":"Electric",
       "Freq":"Scene x2",
       "AC":"7",
@@ -954,7 +954,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Thunder Fang":{  
+   "Thunder Fang":{
       "Type":"Electric",
       "Freq":"At-Will",
       "AC":"3",
@@ -966,7 +966,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Thunderbolt":{  
+   "Thunderbolt":{
       "Type":"Electric",
       "Freq":"EOT",
       "AC":"2",
@@ -978,7 +978,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Thunder Punch":{  
+   "Thunder Punch":{
       "Type":"Electric",
       "Freq":"At-Will",
       "AC":"2",
@@ -990,7 +990,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Thunder Shock":{  
+   "Thunder Shock":{
       "Type":"Electric",
       "Freq":"At-Will",
       "AC":"2",
@@ -1002,16 +1002,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Thunder Wave":{  
+   "Thunder Wave":{
       "Type":"Electric",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"6, 1 Target",
       "Effect":"Thunder Wave cannot miss. Thunder Wave Paralyzes the target. Pokémon immune to Electric Attacks are immune to Thunder Wave's effects.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Volt Switch":{  
+   "Volt Switch":{
       "Type":"Electric",
       "Freq":"At-Will",
       "AC":"2",
@@ -1023,7 +1023,7 @@
       "Contest Effect":"Inversed Appeal",
       "Crits On":20
    },
-   "Volt Tackle":{  
+   "Volt Tackle":{
       "Type":"Electric",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1035,7 +1035,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Wild Charge":{  
+   "Wild Charge":{
       "Type":"Electric",
       "Freq":"At-Will",
       "AC":"2",
@@ -1046,7 +1046,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Zap Cannon":{  
+   "Zap Cannon":{
       "Type":"Electric",
       "Freq":"At-Will",
       "AC":"9",
@@ -1058,16 +1058,16 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Aromatic Mist":{  
+   "Aromatic Mist":{
       "Type":"Fairy",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Burst 1",
       "Effect":"Raise the Special Defense of all allied legal targets by +1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Baby-Doll Eyes":{  
+   "Baby-Doll Eyes":{
       "Type":"Fairy",
       "Freq":"EOT",
       "AC":"2",
@@ -1075,9 +1075,9 @@
       "Range":" 4, 1 Target, Priority, Social",
       "Effect":"Lower the target's Attack by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Charm":{  
+   "Charm":{
       "Type":"Fairy",
       "Freq":"EOT",
       "AC":"2",
@@ -1085,18 +1085,18 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Lower the target’s Attack by -2 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Crafty Shield":{  
+   "Crafty Shield":{
       "Type":"Fairy",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 2, Trigger, Interrupt, Shield",
       "Effect":"If the user or an Ally within 2 meters of Crafty Shield's user is hit by a Status Move, you may use Crafty Shield as an Interrupt. All targets in Crafty Shield's area-of-effect including the user, are instead not hit by the triggering Move and do not suffer any of its effects.",
       "Contest Type":"Smart",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Dazzling Gleam":{  
+   "Dazzling Gleam":{
       "Type":"Fairy",
       "Freq":"EOT",
       "AC":"2",
@@ -1107,7 +1107,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Disarming Voice":{  
+   "Disarming Voice":{
       "Type":"Fairy",
       "Freq":"At-Will",
       "DB":"4",
@@ -1118,7 +1118,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Draining Kiss":{  
+   "Draining Kiss":{
       "Type":"Fairy",
       "Freq":"EOT",
       "AC":"2",
@@ -1130,16 +1130,16 @@
       "Contest Effect":"Good Show!",
       "Crits On":20
    },
-   "Fairy Lock":{  
+   "Fairy Lock":{
       "Type":"Fairy",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 3, Friendly",
       "Effect":"All legal targets become Trapped and Slowed while the user remains in the encounter. If the user is switched or knocked out, this effect ends.",
       "Contest Type":"Cute",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Fairy Wind":{  
+   "Fairy Wind":{
       "Type":"Fairy",
       "Freq":"At-Will",
       "AC":"2",
@@ -1150,25 +1150,25 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Flower Shield":{  
+   "Flower Shield":{
       "Type":"Fairy",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 2",
       "Effect":"Raise the Defense of all Grass-Type legal targets by +2 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Geomancy":{  
+   "Geomancy":{
       "Type":"Fairy",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Set Up",
       "Effect":"Set-Up Effect: The user may not shift this round. The user may create as many squares of Rough Terrain as it wants within a Burst 3 as plants burst through the ground, regardless of the surface material. Resolution Effect: Geomancy raises the user's Special Attack, Special Defense, and Speed by +2 CS.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Catching Up",
+      "Contest Effect":"Catching Up"
    },
-   "Light of Ruin":{  
+   "Light of Ruin":{
       "Type":"Fairy",
       "Freq":"Scene",
       "AC":"4",
@@ -1179,7 +1179,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Sweet Kiss":{  
+   "Sweet Kiss":{
       "Type":"Fairy",
       "Freq":"Scene x2",
       "AC":"6",
@@ -1187,18 +1187,18 @@
       "Range":"6, 1 Target, Social",
       "Effect":"The target is Confused. On miss, the target suffers a -2 penalty to Accuracy Rolls for one full round.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Misty Terrain":{  
+   "Misty Terrain":{
       "Type":"Fairy",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"The area becomes Misty for 5 turns, While Misty, all Pokémon and Traners standing on the ground ignore the first turn of all Status Afflictions, and Dragon-type attacks targeting or origination from a grounded Pokémon or Trainer take a -10 Penalty to Damage Rolls.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Moonblast":{  
+   "Moonblast":{
       "Type":"Fairy",
       "Freq":"EOT",
       "AC":"2",
@@ -1210,16 +1210,16 @@
       "Contest Effect":"Reflective Apeal",
       "Crits On":20
    },
-   "Moonlight":{  
+   "Moonlight":{
       "Type":"Fairy",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP. If it is Sunny, the user gains 2/3 of its full HP. If it is Rainy, Sand Storming, or Hailing, the user gains 1/4 of its full HP.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Play Rough":{  
+   "Play Rough":{
       "Type":"Fairy",
       "Freq":"EOT",
       "AC":"4",
@@ -1231,7 +1231,7 @@
       "Contest Effect":"Excitement",
       "Crits On":20
    },
-   "Arm Thrust":{  
+   "Arm Thrust":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"4",
@@ -1242,7 +1242,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Aura Sphere":{  
+   "Aura Sphere":{
       "Type":"Fighting",
       "Freq":"EOT",
       "DB":"8",
@@ -1253,7 +1253,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Brick Break":{  
+   "Brick Break":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1265,16 +1265,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Bulk Up":{  
+   "Bulk Up":{
       "Type":"Fighting",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Defense by +1 CS each.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Circle Throw":{  
+   "Circle Throw":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"4",
@@ -1286,7 +1286,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Close Combat":{  
+   "Close Combat":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1298,7 +1298,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Counter":{  
+   "Counter":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "DB":"See Effect",
@@ -1309,7 +1309,7 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Cross Chop":{  
+   "Cross Chop":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "AC":"4",
@@ -1321,16 +1321,16 @@
       "Contest Effect":"Desperation",
       "Crits On":16
    },
-   "Detect":{  
+   "Detect":{
       "Type":"Fighting",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Trigger, Interrupt, Shield",
       "Effect":"If the user is hit by a Move, the user may use Detect. The user is instead not hit by the Move. You do not take any damage nor are you affected by anty of the Move's effects",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Double Kick":{  
+   "Double Kick":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"3",
@@ -1341,7 +1341,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Drain Punch":{  
+   "Drain Punch":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1353,7 +1353,7 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Dynamic Punch":{  
+   "Dynamic Punch":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"9",
@@ -1365,7 +1365,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Final Gambit":{  
+   "Final Gambit":{
       "Type":"Fighting",
       "Freq":"Scene",
       "AC":"2",
@@ -1376,7 +1376,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Flying Press":{  
+   "Flying Press":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"3",
@@ -1388,7 +1388,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Focus Blast":{  
+   "Focus Blast":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "AC":"7",
@@ -1400,7 +1400,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Focus Punch":{  
+   "Focus Punch":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1412,7 +1412,7 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Force Palm":{  
+   "Force Palm":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1424,7 +1424,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Hammer Arm":{  
+   "Hammer Arm":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"3",
@@ -1436,7 +1436,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "High Jump Kick":{  
+   "High Jump Kick":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"3",
@@ -1448,7 +1448,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Jump Kick":{  
+   "Jump Kick":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"3",
@@ -1460,7 +1460,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Karate Chop":{  
+   "Karate Chop":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1472,7 +1472,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":17
    },
-   "Low Kick":{  
+   "Low Kick":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"2",
@@ -1484,7 +1484,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Low Sweep":{  
+   "Low Sweep":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"2",
@@ -1496,7 +1496,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Mach Punch":{  
+   "Mach Punch":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1507,16 +1507,16 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Mat Block":{  
+   "Mat Block":{
       "Type":"Fighting",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Trigger, Interrupt, Shield",
       "Effect":"If the user or an adjacent ally is hit by a damagin attack, the user may use Mat Block. The attack instead does not hit any targets, and it deals no damage and has no effects. You may only use Mat Block during the first round of an encounter",
       "Contest Type":"Tough",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Power-Up Punch":{  
+   "Power-Up Punch":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"2",
@@ -1528,16 +1528,16 @@
       "Contest Effect":"Catching Up",
       "Crits On":20
    },
-   "Quick Guard":{  
+   "Quick Guard":{
       "Type":"Fighting",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Melee, Interrupt, Shield, Trigger",
       "Effect":"If the user or an adjacent ally is targeted by a Priority or Interrupt Attack, Quick Guard may be declared as an Interrupt, causing the triggering attack to have no effect.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Revenge":{  
+   "Revenge":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"2",
@@ -1549,7 +1549,7 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Reversal":{  
+   "Reversal":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"2",
@@ -1561,7 +1561,7 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Rock Smash":{  
+   "Rock Smash":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1573,7 +1573,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Rolling Kick":{  
+   "Rolling Kick":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"4",
@@ -1585,7 +1585,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Sacred Sword":{  
+   "Sacred Sword":{
       "Type":"Fighting",
       "Freq":"EOT",
       "DB":"8",
@@ -1596,7 +1596,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Secret Sword":{  
+   "Secret Sword":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1608,7 +1608,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Seismic Toss":{  
+   "Seismic Toss":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1619,7 +1619,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Sky Uppercut":{  
+   "Sky Uppercut":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"4",
@@ -1631,7 +1631,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Storm Throw":{  
+   "Storm Throw":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"2",
@@ -1643,7 +1643,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":0
    },
-   "Submission":{  
+   "Submission":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"6",
@@ -1655,7 +1655,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Superpower":{  
+   "Superpower":{
       "Type":"Fighting",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1667,7 +1667,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Triple Kick":{  
+   "Triple Kick":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"3",
@@ -1679,7 +1679,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Vacuum Wave":{  
+   "Vacuum Wave":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1690,7 +1690,7 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Vital Throw":{  
+   "Vital Throw":{
       "Type":"Fighting",
       "Freq":"EOT",
       "DB":"7",
@@ -1701,7 +1701,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Wake-Up Slap":{  
+   "Wake-Up Slap":{
       "Type":"Fighting",
       "Freq":"At-Will",
       "AC":"2",
@@ -1713,7 +1713,7 @@
       "Contest Effect":"Inversed Appeal",
       "Crits On":20
    },
-   "Blast Burn":{  
+   "Blast Burn":{
       "Type":"Fire",
       "Freq":"Daily x2",
       "AC":"4",
@@ -1724,7 +1724,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Blaze Kick":{  
+   "Blaze Kick":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"4",
@@ -1736,7 +1736,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":18
    },
-   "Blue Flare":{  
+   "Blue Flare":{
       "Type":"Fire",
       "Freq":"Scene x2",
       "AC":"5",
@@ -1748,7 +1748,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Ember":{  
+   "Ember":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"2",
@@ -1760,7 +1760,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Eruption":{  
+   "Eruption":{
       "Type":"Fire",
       "Freq":"Daily",
       "AC":"4",
@@ -1772,7 +1772,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Fiery Dance":{  
+   "Fiery Dance":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"2",
@@ -1784,7 +1784,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Fire Blast":{  
+   "Fire Blast":{
       "Type":"Fire",
       "Freq":"Scene x2",
       "AC":"4",
@@ -1796,7 +1796,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Fire Fang":{  
+   "Fire Fang":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"3",
@@ -1808,7 +1808,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Fire Pledge":{  
+   "Fire Pledge":{
       "Type":"Fire",
       "Freq":"Scene",
       "AC":"2",
@@ -1820,7 +1820,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Fire Punch":{  
+   "Fire Punch":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"2",
@@ -1832,7 +1832,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Fire Spin":{  
+   "Fire Spin":{
       "Type":"Fire",
       "Freq":"Scene x2",
       "AC":"4",
@@ -1844,7 +1844,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Flame Burst":{  
+   "Flame Burst":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"2",
@@ -1856,7 +1856,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Flame Charge":{  
+   "Flame Charge":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"2",
@@ -1868,7 +1868,7 @@
       "Contest Effect":"Excitement",
       "Crits On":20
    },
-   "Flame Wheel":{  
+   "Flame Wheel":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"2",
@@ -1880,7 +1880,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Flamethrower":{  
+   "Flamethrower":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"2",
@@ -1892,7 +1892,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Flare Blitz":{  
+   "Flare Blitz":{
       "Type":"Fire",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1904,7 +1904,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Fusion Flare":{  
+   "Fusion Flare":{
       "Type":"Fire",
       "Freq":"Scene x2",
       "AC":"2",
@@ -1916,7 +1916,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Heat Crash":{  
+   "Heat Crash":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"2",
@@ -1928,7 +1928,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Heat Wave":{  
+   "Heat Wave":{
       "Type":"Fire",
       "Freq":"Scene x2",
       "AC":"4",
@@ -1940,7 +1940,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Incinerate":{  
+   "Incinerate":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"2",
@@ -1952,7 +1952,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Inferno":{  
+   "Inferno":{
       "Type":"Fire",
       "Freq":"At-Will",
       "AC":"9",
@@ -1964,7 +1964,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Lava Plume":{  
+   "Lava Plume":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"2",
@@ -1976,7 +1976,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Magma Storm":{  
+   "Magma Storm":{
       "Type":"Fire",
       "Freq":"Scene",
       "AC":"6",
@@ -1988,7 +1988,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Mystical Fire":{  
+   "Mystical Fire":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"2",
@@ -2000,7 +2000,7 @@
       "Contest Effect":"Special Attention",
       "Crits On":20
    },
-   "Overheat":{  
+   "Overheat":{
       "Type":"Fire",
       "Freq":"Scene",
       "AC":"4",
@@ -2012,7 +2012,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Sacred Fire":{  
+   "Sacred Fire":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"3",
@@ -2024,7 +2024,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Searing Shot":{  
+   "Searing Shot":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"2",
@@ -2036,16 +2036,16 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Sunny Day":{  
+   "Sunny Day":{
       "Type":"Fire",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field, Weather",
       "Effect":"The weather becomes Sunny for 5 rounds. While Sunny, Fire-Type Attacks gain a +5 bonus to Damage Rolls, and Water-Type Attacks suffer a -5 Damage penalty.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "V-Create":{  
+   "V-Create":{
       "Type":"Fire",
       "Freq":"Daily",
       "AC":"5",
@@ -2057,7 +2057,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Will-O-Wisp":{  
+   "Will-O-Wisp":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"5",
@@ -2065,9 +2065,9 @@
       "Range":"6, 1 Target",
       "Effect":"The target is Burned.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act",
+      "Contest Effect":"Exhausting Act"
    },
-   "Acrobatics":{  
+   "Acrobatics":{
       "Type":"Flying",
       "Freq":"EOT",
       "AC":"2",
@@ -2079,7 +2079,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Aerial Ace":{  
+   "Aerial Ace":{
       "Type":"Flying",
       "Freq":"EOT",
       "DB":"6",
@@ -2090,7 +2090,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Aeroblast":{  
+   "Aeroblast":{
       "Type":"Flying",
       "Freq":"Daily",
       "AC":"3",
@@ -2102,7 +2102,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":"Even"
    },
-   "Air Cutter":{  
+   "Air Cutter":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"2",
@@ -2114,7 +2114,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":18
    },
-   "Air Slash":{  
+   "Air Slash":{
       "Type":"Flying",
       "Freq":"EOT",
       "AC":"3",
@@ -2126,7 +2126,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Bounce":{  
+   "Bounce":{
       "Type":"Flying",
       "Freq":"Scene x2",
       "AC":"4",
@@ -2138,7 +2138,7 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Brave Bird":{  
+   "Brave Bird":{
       "Type":"Flying",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2150,7 +2150,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Chatter":{  
+   "Chatter":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"2",
@@ -2162,16 +2162,16 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Defog":{  
+   "Defog":{
       "Type":"Flying",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field, Weather",
       "Effect":"The Weather becomes Clear, and all Blessings, Coats, and Hazards are destroyed. Clear Weather is the default weather, conferring no bonuses or penalties of any sort.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Dragon Ascent":{  
+   "Dragon Ascent":{
       "Type":"Flying",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2183,7 +2183,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Drill Peck":{  
+   "Drill Peck":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"2",
@@ -2194,7 +2194,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Feather Dance":{  
+   "Feather Dance":{
       "Type":"Flying",
       "Freq":"EOT",
       "AC":"2",
@@ -2202,9 +2202,9 @@
       "Range":"Burst 1, Friendly",
       "Effect":"All legal targets have their Attack lowered 2 Combat Stages.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Fly":{  
+   "Fly":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"3",
@@ -2216,7 +2216,7 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Gust":{  
+   "Gust":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"2",
@@ -2228,7 +2228,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Hurricane":{  
+   "Hurricane":{
       "Type":"Flying",
       "Freq":"Scene x2",
       "AC":"7",
@@ -2240,7 +2240,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Mirror Move":{  
+   "Mirror Move":{
       "Type":"Flying",
       "Freq":"Scene x2",
       "DB":"See Effect",
@@ -2248,9 +2248,9 @@
       "Range":"6, 1 Target, Illusion",
       "Effect":"Use the Move the target has used on their last turn. You may choose new targets for the Move. Mirror Move cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Double TIme",
+      "Contest Effect":"Double TIme"
    },
-   "Oblivion Wing":{  
+   "Oblivion Wing":{
       "Type":"Flying",
       "Freq":"Daily",
       "AC":"2",
@@ -2262,7 +2262,7 @@
       "Contest Effect":"Catching Up",
       "Crits On":20
    },
-   "Peck":{  
+   "Peck":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"2",
@@ -2273,7 +2273,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Pluck":{  
+   "Pluck":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"2",
@@ -2285,16 +2285,16 @@
       "Contest Effect":"Attention Grabber",
       "Crits On":20
    },
-   "Roost":{  
+   "Roost":{
       "Type":"Flying",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP. If the user is a Flying Type, it loses the Flying Type until the start of their next turn.",
       "Contest Type":"Cool",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Sky Attack":{  
+   "Sky Attack":{
       "Type":"Flying",
       "Freq":"Scene x2",
       "AC":"4",
@@ -2306,7 +2306,7 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Sky Drop":{  
+   "Sky Drop":{
       "Type":"Flying",
       "Freq":"Scene x2",
       "AC":"3",
@@ -2318,16 +2318,16 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Tailwind":{  
+   "Tailwind":{
       "Type":"Flying",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Blessing",
       "Effect":"For the remainder of the encounter, all allied trainers and Pokémon gain +5 to their Initiative. Multiple instances of Tailwind cannot stack. *Grants: Guster",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace",
+      "Contest Effect":"Saving Grace"
    },
-   "Wing Attack":{  
+   "Wing Attack":{
       "Type":"Flying",
       "Freq":"At-Will",
       "AC":"2",
@@ -2338,7 +2338,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Astonish":{  
+   "Astonish":{
       "Type":"Ghost",
       "Freq":"At-Will",
       "AC":"2",
@@ -2350,7 +2350,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Confuse Ray":{  
+   "Confuse Ray":{
       "Type":"Ghost",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2358,36 +2358,36 @@
       "Range":"6, 1 Target",
       "Effect":"The target is Confused.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Curse":{  
+   "Curse":{
       "Type":"Ghost",
       "Freq":"See Text",
       "Class":"Status",
       "Range":"Self",
       "Effect":"If the user is not a Ghost Type, Curse has a Frequency of EOT, and when used the user lowers its Speed by -1 Combat Stage, but raises Attack and Defense by +1 Combat Stage each. If the user is a Ghost Type, Curse has a Frequency of Scene, and when used the user loses 1/3 of their Max Hit Points and a target Pokémon or Trainer within 8 meters of the user becomes Cursed. This Hit Point loss cannot be prevented in any way.",
       "Contest Type":"Tough",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Destiny Bond":{  
+   "Destiny Bond":{
       "Type":"Ghost",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Burst 10, Friendly",
       "Effect":"All enemy targets in the burst become Bound to the user until the end of your next turn. If a Bound target causes the user to Faint through a Damaging Attack, the Bound target immediately faints after their attack is resolved.",
       "Contest Type":"Smart",
-      "Contest Effect":"Big Show",
+      "Contest Effect":"Big Show"
    },
-   "Grudge":{  
+   "Grudge":{
       "Type":"Ghost",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"6, 1 Target, Interrupt",
       "Effect":"You may use Grudge as an Interrupt when a Damaging Attack causes the user to faint. Grudge is activated as a Free Action (does not take up a Command.) The attack is resolved as usual, and the user Faints. The attacker that caused the user to Faint becomes Suppressed for the remainder of the encounter; switching and Taking a Breather does not end Suppression when used this way.",
       "Contest Type":"Tough",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Hex":{  
+   "Hex":{
       "Type":"Ghost",
       "Freq":"EOT",
       "AC":"2",
@@ -2399,7 +2399,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Lick":{  
+   "Lick":{
       "Type":"Ghost",
       "Freq":"At-Will",
       "AC":"2",
@@ -2411,7 +2411,7 @@
       "Contest Effect":"Inversed Appeal",
       "Crits On":20
    },
-   "Night Shade":{  
+   "Night Shade":{
       "Type":"Ghost",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2422,7 +2422,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Nightmare":{  
+   "Nightmare":{
       "Type":"Ghost",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2430,9 +2430,9 @@
       "Range":"Melee, 1 Target",
       "Effect":"Nightmare can only hit Legal Targets that are Asleep. The target gains Bad Sleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Ominous Wind":{  
+   "Ominous Wind":{
       "Type":"Ghost",
       "Freq":"EOT",
       "AC":"2",
@@ -2444,7 +2444,7 @@
       "Contest Effect":"Get Ready!",
       "Crits On":20
    },
-   "Phantom Force":{  
+   "Phantom Force":{
       "Type":"Ghost",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2456,7 +2456,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Shadow Ball":{  
+   "Shadow Ball":{
       "Type":"Ghost",
       "Freq":"EOT",
       "AC":"2",
@@ -2468,7 +2468,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Shadow Claw":{  
+   "Shadow Claw":{
       "Type":"Ghost",
       "Freq":"EOT",
       "AC":"2",
@@ -2480,7 +2480,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":18
    },
-   "Shadow Force":{  
+   "Shadow Force":{
       "Type":"Ghost",
       "Freq":"Daily x3",
       "AC":"2",
@@ -2492,7 +2492,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Shadow Punch":{  
+   "Shadow Punch":{
       "Type":"Ghost",
       "Freq":"EOT",
       "DB":"6",
@@ -2503,7 +2503,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Shadow Sneak":{  
+   "Shadow Sneak":{
       "Type":"Ghost",
       "Freq":"At-Will",
       "AC":"2",
@@ -2514,16 +2514,16 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Spite":{  
+   "Spite":{
       "Type":"Ghost",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"1 Target, Trigger",
       "Effect":"Spite may be used as a Free Action that does not take up a Command whenever the user is hit by a Move. That Move becomes Disabled for the attacker.",
       "Contest Type":"Tough",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Trick-or-Treat":{  
+   "Trick-or-Treat":{
       "Type":"Ghost",
       "Freq":"Daily",
       "AC":"2",
@@ -2531,9 +2531,9 @@
       "Range":"6, 1 Target",
       "Effect":"The target gains the Ghost Type in addition to its other Types for 5 turns.",
       "Contest Type":"Cute",
-      "Contest Effect":"Good Show!",
+      "Contest Effect":"Good Show!"
    },
-   "Absorb":{  
+   "Absorb":{
       "Type":"Grass",
       "Freq":"At-Will",
       "AC":"2",
@@ -2545,16 +2545,16 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Aromatherapy":{  
+   "Aromatherapy":{
       "Type":"Grass",
       "Freq":"Scene ",
       "Class":"Status",
       "Range":"Burst 1",
       "Effect":"All allies in the burst are cured of one status condition of their choice.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Bullet Seed":{  
+   "Bullet Seed":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"4",
@@ -2565,16 +2565,16 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Cotton Guard":{  
+   "Cotton Guard":{
       "Type":"Grass",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Defense 3 Combat Stages.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Cotton Spore":{  
+   "Cotton Spore":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"2",
@@ -2582,9 +2582,9 @@
       "Range":"Burst 1, Powder",
       "Effect":"All legal targets have their Speed lowered 2 Combat Stages.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Saving Grace",
+      "Contest Effect":"Saving Grace"
    },
-   "Energy Ball":{  
+   "Energy Ball":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"2",
@@ -2596,7 +2596,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Forest's Curse":{  
+   "Forest's Curse":{
       "Type":"Grass",
       "Freq":"Daily",
       "AC":"2",
@@ -2604,9 +2604,9 @@
       "Range":"6, 1 Target",
       "Effect":"The target gains the Grass Type in addition to its other Types for 5 turns.",
       "Contest Type":"Smart",
-      "Contest Effect":"Good Show!",
+      "Contest Effect":"Good Show!"
    },
-   "Frenzy Plant":{  
+   "Frenzy Plant":{
       "Type":"Grass",
       "Freq":"Daily x2",
       "AC":"4",
@@ -2617,7 +2617,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Giga Drain":{  
+   "Giga Drain":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2629,7 +2629,7 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Grass Knot":{  
+   "Grass Knot":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"2",
@@ -2641,7 +2641,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Grass Pledge":{  
+   "Grass Pledge":{
       "Type":"Grass",
       "Freq":"Scene",
       "AC":"2",
@@ -2653,7 +2653,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Grasswhistle":{  
+   "Grasswhistle":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"6",
@@ -2661,18 +2661,18 @@
       "Range":"6, 1 Target, Sonic",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Grassy Terrain":{  
+   "Grassy Terrain":{
       "Type":"Grass",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"The area becomes Grassy for 5 rounds. While Grassy, all Pokémon and Trainers standing on the ground recover 1/10th of their maximum Hit Points at the start of every turn, and Grass-Type attacks performed by grounded Pokémon and Trainers gain a +10 bonus to Damage Rolls.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready",
+      "Contest Effect":"Get Ready"
    },
-   "Horn Leech":{  
+   "Horn Leech":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2684,16 +2684,16 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Ingrain":{  
+   "Ingrain":{
       "Type":"Grass",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Coat",
       "Effect":"Ingrain applies a Coat to the user, which has the following effect; the user cannot be pushed or pulled, and cannot be switched out. At the beginning of each of the user's turn, the user gains HP equal to 1/10th of its max HP.",
       "Contest Type":"Smart",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Leaf Blade":{  
+   "Leaf Blade":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"2",
@@ -2705,7 +2705,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":18
    },
-   "Leaf Storm":{  
+   "Leaf Storm":{
       "Type":"Grass",
       "Freq":"Scene",
       "AC":"4",
@@ -2717,7 +2717,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Leaf Tornado":{  
+   "Leaf Tornado":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"4",
@@ -2729,7 +2729,7 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Leech Seed":{  
+   "Leech Seed":{
       "Type":"Grass",
       "Freq":"Daily x2",
       "AC":"4",
@@ -2737,9 +2737,9 @@
       "Range":"6, 1 Target",
       "Effect":"At the beginning of each of the target's turns, Leech Seed's target loses 1/10th of their full HP. Leech Seed's user then gains HP equal to the amount the target lost. Leech Seed lasts until the target faints or is returned to a Poké Ball. Grass Types and targets immune to Grass Attacks are immune to Leech Seed",
       "Contest Type":"Smart",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Magical Leaf":{  
+   "Magical Leaf":{
       "Type":"Grass",
       "Freq":"EOT",
       "DB":"6",
@@ -2750,7 +2750,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Mega Drain":{  
+   "Mega Drain":{
       "Type":"Grass",
       "Freq":"At-Will",
       "AC":"2",
@@ -2762,7 +2762,7 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Needle Arm":{  
+   "Needle Arm":{
       "Type":"Grass",
       "Freq":"At-Will",
       "AC":"2",
@@ -2774,7 +2774,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Petal Blizzard":{  
+   "Petal Blizzard":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"2",
@@ -2785,7 +2785,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Petal Dance":{  
+   "Petal Dance":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"3",
@@ -2797,7 +2797,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Power Whip":{  
+   "Power Whip":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"5",
@@ -2809,7 +2809,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Razor Leaf":{  
+   "Razor Leaf":{
       "Type":"Grass",
       "Freq":"At-Will",
       "AC":"4",
@@ -2821,7 +2821,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":18
    },
-   "Seed Bomb":{  
+   "Seed Bomb":{
       "Type":"Grass",
       "Freq":"At-Will",
       "AC":"2",
@@ -2832,7 +2832,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Seed Flare":{  
+   "Seed Flare":{
       "Type":"Grass",
       "Freq":"Scene",
       "AC":"5",
@@ -2844,7 +2844,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Sleep Powder":{  
+   "Sleep Powder":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"6",
@@ -2852,9 +2852,9 @@
       "Range":"4, 1 Target, Powder",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Solar Beam":{  
+   "Solar Beam":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2866,25 +2866,25 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Spiky Shield":{  
+   "Spiky Shield":{
       "Type":"Grass",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Interrupt, Shield, Trigger",
       "Effect":"If the user is hit by an attack, the user may use Spiky Shield. The user is instead not hit by the Move. You do not take any damage nor are you affected by any of the Move’s effects. In addition, if the triggering attack was Melee-ranged, the attacker loses Hit Points equal to 1/10th of their Max Hit Points.",
       "Contest Type":"Tough",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Spore":{  
+   "Spore":{
       "Type":"Grass",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"4, 1 Target, Powder",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Stun Spore":{  
+   "Stun Spore":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"6",
@@ -2892,18 +2892,18 @@
       "Range":"6, 1 Target, Powder",
       "Effect":"The target is Paralyzed.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Synthesis":{  
+   "Synthesis":{
       "Type":"Grass",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user regains Hit Points equal to half of its full Hit Point value. If it is Sunny, the user gains 2/3 of its full Hit Point value. If it is Rainy, Sand Storming, or Hailing, the user gains 1/4 of its full Hit Point value.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Vine Whip":{  
+   "Vine Whip":{
       "Type":"Grass",
       "Freq":"At-Will",
       "AC":"2",
@@ -2915,7 +2915,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Wood Hammer":{  
+   "Wood Hammer":{
       "Type":"Grass",
       "Freq":"Scene x2",
       "AC":"2",
@@ -2926,7 +2926,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Worry Seed":{  
+   "Worry Seed":{
       "Type":"Grass",
       "Freq":"Scene",
       "AC":"2",
@@ -2934,9 +2934,9 @@
       "Range":"8, 1 Target",
       "Effect":"The target's Ability is replaced with Insomnia. If the target has multiple Abilities, Worry Seed only replaces one, chosen at random.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Bone Club":{  
+   "Bone Club":{
       "Type":"Ground",
       "Freq":"At-Will",
       "AC":"5",
@@ -2948,7 +2948,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Bone Rush":{  
+   "Bone Rush":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"4",
@@ -2959,7 +2959,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Bonemerang":{  
+   "Bonemerang":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"3",
@@ -2970,7 +2970,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Bulldoze":{  
+   "Bulldoze":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"2",
@@ -2982,7 +2982,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Dig":{  
+   "Dig":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"2",
@@ -2994,7 +2994,7 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Drill Run":{  
+   "Drill Run":{
       "Type":"Ground",
       "Freq":"At-Will",
       "AC":"3",
@@ -3006,7 +3006,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":18
    },
-   "Earth Power":{  
+   "Earth Power":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"2",
@@ -3018,7 +3018,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Earthquake":{  
+   "Earthquake":{
       "Type":"Ground",
       "Freq":"Scene",
       "AC":"2",
@@ -3030,16 +3030,16 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Fissure":{  
+   "Fissure":{
       "Type":"Ground",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"5, 1 Target, Execute, Groundsource",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level. *Grants: Groundshaper",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show",
+      "Contest Effect":"Big Show"
    },
-   "Land's Wrath":{  
+   "Land's Wrath":{
       "Type":"Ground",
       "Freq":"Scene x2",
       "AC":"2",
@@ -3051,7 +3051,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Magnitude":{  
+   "Magnitude":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"2",
@@ -3063,7 +3063,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Mud Bomb":{  
+   "Mud Bomb":{
       "Type":"Ground",
       "Freq":"At-Will",
       "AC":"4",
@@ -3075,7 +3075,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Mud Shot":{  
+   "Mud Shot":{
       "Type":"Ground",
       "Freq":"At-Will",
       "AC":"3",
@@ -3087,16 +3087,16 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Mud Sport":{  
+   "Mud Sport":{
       "Type":"Ground",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Burst 2",
       "Effect":"All targets in the burst, including the user, gain a Coat which grants them 1 Step of Resistance to Electric Type Moves. After a target has been hit by a damaging Electric Type Move, the coat is removed.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Mud-Slap":{  
+   "Mud-Slap":{
       "Type":"Ground",
       "Freq":"At-Will",
       "AC":"2",
@@ -3108,7 +3108,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Preicpice Blades":{  
+   "Preicpice Blades":{
       "Type":"Ground",
       "Freq":"Scene x2",
       "AC":"5",
@@ -3119,16 +3119,16 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Rototiller":{  
+   "Rototiller":{
       "Type":"Ground",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 2",
       "Effect":"All Grass-type Pokémon in the area raise their Attack and Special Attack 1 Combat Stage.",
       "Contest Type":"Tough",
-      "Contest Effect":"Special Attention",
+      "Contest Effect":"Special Attention"
    },
-   "Sand Tomb":{  
+   "Sand Tomb":{
       "Type":"Ground",
       "Freq":"Scene x2",
       "AC":"4",
@@ -3140,7 +3140,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Sand Attack":{  
+   "Sand Attack":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"2",
@@ -3148,18 +3148,18 @@
       "Range":"2, 1 Target",
       "Effect":"The target is Blinded until the end of their next turn.",
       "Contest Type":"Cute",
-      "Contest Effect":" Excitement",
+      "Contest Effect":" Excitement"
    },
-   "Spikes":{  
+   "Spikes":{
       "Type":"Ground",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"6, Hazard",
       "Effect":"Set 8 square meters of Spikes within the range such that all 8 meters are adjacent with at least one other space of Spikes. Spikes cause terrain to count as Slow Terrain, and a grounded foe that runs into the hazards will lose 1/10th of their full HP and become Slowed until the end of their next turn.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Aurora Beam":{  
+   "Aurora Beam":{
       "Type":"Ice",
       "Freq":"At-Will",
       "AC":"2",
@@ -3171,7 +3171,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Avalanche":{  
+   "Avalanche":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"2",
@@ -3183,7 +3183,7 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Blizzard":{  
+   "Blizzard":{
       "Type":"Ice",
       "Freq":"Scene x2",
       "AC":"7",
@@ -3195,7 +3195,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Freeze-Dry":{  
+   "Freeze-Dry":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"2",
@@ -3207,7 +3207,7 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Freeze Shock":{  
+   "Freeze Shock":{
       "Type":"Ice",
       "Freq":"Scene",
       "AC":"4",
@@ -3219,7 +3219,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Frost Breath":{  
+   "Frost Breath":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"3",
@@ -3231,7 +3231,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":0
    },
-   "Glaciate":{  
+   "Glaciate":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"3",
@@ -3243,25 +3243,25 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Hail":{  
+   "Hail":{
       "Type":"Ice",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field, Weather",
       "Effect":"The weather changes to Hail for 5 rounds. While it is Hailing, all non-Ice Type Pokémon lose a Tick of Hit Points at the beginning of their turn.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Haze":{  
+   "Haze":{
       "Type":"Ice",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"The Combat Stages of the user and all Pokémon and Trainers in the encounter are set to their default state (usually 0).",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Ice Ball":{  
+   "Ice Ball":{
       "Type":"Ice",
       "Freq":"At-Will",
       "AC":"4",
@@ -3273,7 +3273,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Ice Beam":{  
+   "Ice Beam":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"2",
@@ -3285,7 +3285,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Ice Burn":{  
+   "Ice Burn":{
       "Type":"Ice",
       "Freq":"Scene",
       "AC":"4",
@@ -3297,7 +3297,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Ice Fang":{  
+   "Ice Fang":{
       "Type":"Ice",
       "Freq":"At-Will",
       "AC":"3",
@@ -3309,7 +3309,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Ice Punch":{  
+   "Ice Punch":{
       "Type":"Ice",
       "Freq":"At-Will",
       "AC":"2",
@@ -3321,7 +3321,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Ice Shard":{  
+   "Ice Shard":{
       "Type":"Ice",
       "Freq":"At-Will",
       "AC":"2",
@@ -3332,7 +3332,7 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Icicle Crash":{  
+   "Icicle Crash":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"4",
@@ -3344,7 +3344,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Icicle Spear":{  
+   "Icicle Spear":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"4",
@@ -3355,7 +3355,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Icy Wind":{  
+   "Icy Wind":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"3",
@@ -3367,16 +3367,16 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Mist":{  
+   "Mist":{
       "Type":"Ice",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Blessing",
       "Effect":"Any user affected by Mist may activate it when having Combat Stages lowered by any effect; if they do, those Combat Stages are instead not lowered. Mist may be activated 3 times and then disappears.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Powder Snow":{  
+   "Powder Snow":{
       "Type":"Ice",
       "Freq":"At-Will",
       "AC":"2",
@@ -3388,16 +3388,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Sheer Cold":{  
+   "Sheer Cold":{
       "Type":"Ice",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"4, 1 Target, Execute",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level. *Grants: Freezer",
       "Contest Type":"Beauty",
-      "Contest Effect":"Big Show",
+      "Contest Effect":"Big Show"
    },
-   "Acupressure":{  
+   "Acupressure":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3405,27 +3405,27 @@
       "Range":"Melee, 1 Target or Self",
       "Effect":"Roll 1d6. On a result of 1, raise the target’s Attack by +2 CS. On a result of 2, raise the target’s Defense by +2 CS. On a result of 3, raise the target’s Special Attack by +2 CS. On a result of 4, raise the target’s Special Defense by +2 CS. On a result of 5, raise the target’s Speed by +2 CS. On a result of 6, raise the target’s Accuracy by +2.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "After You":{  
+   "After You":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"6, 1 Target",
       "Effect":"After You is a Swift Action. The target takes their turn for the round immediately after the user finishes their turn, ignoring Initiative. After You may only affect a target that has not yet acted that round and can only affect willing targets.",
       "Contest Type":"Smart",
-      "Contest Effect":"Desperation",
+      "Contest Effect":"Desperation"
    },
-   "Assist":{  
+   "Assist":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Randomly select another Pokémon on the user’s roster and then randomly select a Move that Pokémon knows. Assist’s user uses that Move immediately.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Attract":{  
+   "Attract":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -3433,9 +3433,9 @@
       "Range":"3, 1 Target, Social",
       "Effect":"Attract Infatuates the target if its gender is the opposite of the user’s. Attract fails when used by or against Genderless targets.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Barrage":{  
+   "Barrage":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"4",
@@ -3446,34 +3446,34 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Baton Pass":{  
+   "Baton Pass":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user is replaced with another Pokémon from their trainer’s roster. All Combat Stage, Coats, and [Stratagems] on Baton Pass’ user are transferred to the replacement. Baton Pass may be used to switch even if the user is Trapped.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Belly Drum":{  
+   "Belly Drum":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user gains +6 Attack CS and loses HP equal to 1/2 of their Max HP.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Bestow":{  
+   "Bestow":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The user gives its held item to the target, unless the target is already holding an item. Using Bestow is a Swift Action.",
       "Contest Type":"Cute",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Bide":{  
+   "Bide":{
       "Type":"Normal",
       "Freq":"Scene",
       "DB":"See Effect",
@@ -3484,7 +3484,7 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Bind":{  
+   "Bind":{
       "Type":"Normal",
       "Freq":"Static",
       "Class":"Static",
@@ -3494,7 +3494,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Block":{  
+   "Block":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3502,9 +3502,9 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target is Stuck and Trapped until the beginning of your next turn.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Body Slam":{  
+   "Body Slam":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -3516,7 +3516,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Boomburst":{  
+   "Boomburst":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -3527,16 +3527,16 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Camouflage":{  
+   "Camouflage":{
       "Type":"Normal",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user changes their Type to match the field. Forests and grassy areas change the user into a Grass Type. Watery areas change the user into a Water Type. Caves and Mountains could change the user into a Rock or Ground Type. An icy terrain would turn the user into an Ice Type. A building may change the user into a Steel or Normal Type. Weather affects what Type the user becomes. Use common sense; if you are having difficult determining what Type the user should become, consult the GM. *Grants Blender",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Captivate":{  
+   "Captivate":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3544,9 +3544,9 @@
       "Range":"Cone 2, Friendly, Social",
       "Effect":"Captivate lowers the target's Special Attack by -2 CS. Captivate may not affect something that is the same gender as the user or something that is genderless.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Chip Away":{  
+   "Chip Away":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3558,7 +3558,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Comet Punch":{  
+   "Comet Punch":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"4",
@@ -3569,7 +3569,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Confide":{  
+   "Confide":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3577,9 +3577,9 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Lower the target's Special Attack by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Constrict":{  
+   "Constrict":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3591,34 +3591,34 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Conversion":{  
+   "Conversion":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user becomes the elemental Type of their choice as long as they have a Move that is the same elemental Type until the end of the encounter. Replace all other Types.",
       "Contest Type":"Beauty",
-      "Contest Effect":" Catching Up",
+      "Contest Effect":" Catching Up"
    },
-   "Conversion2":{  
+   "Conversion2":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user becomes the elemental Type of their choice as long as the Type resists the elemental Type of the Move it last took damage from until the end of the encounter. Replace all other Types.",
       "Contest Type":"Beauty",
-      "Contest Effect":" Catching Up",
+      "Contest Effect":" Catching Up"
    },
-   "Copycat":{  
+   "Copycat":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"4, 1 Target",
       "Effect":"Use the Move the target has used on their last turn. You may choose new targets for the Move. Copycat cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Covet":{  
+   "Covet":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3630,7 +3630,7 @@
       "Contest Effect":"Attention Grabber",
       "Crits On":20
    },
-   "Crush Claw":{  
+   "Crush Claw":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"3",
@@ -3642,7 +3642,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Crush Grip":{  
+   "Crush Grip":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -3654,7 +3654,7 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Cut":{  
+   "Cut":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"3",
@@ -3666,25 +3666,25 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Defense Curl":{  
+   "Defense Curl":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user becomes Curled Up. While Curled Up, the user becomes immune to Critical Hits and gains 10 Damage Reduction. However, while Curled Up, the user is Slowed and their Accuracy is lowered by -4. The user may stop being Curled Up as a Swift Action. If the user has Rollout or Ice Ball in their Move List, they do not become Slowed while Curled Up. Furthermore, when using the Moves Rollout or Ice Ball while Curled Up, the user gains a +10 bonus to the damage rolls of those Moves and does not suffer Accuracy Penalties from being Curled Up.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Disable":{  
+   "Disable":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"1 Target, Trigger",
       "Effect":"Disable may be used as a Free Action that does not take up a Command whenever the user is hit by a Move. That Move becomes Disabled for the attacker.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Dizzy Punch":{  
+   "Dizzy Punch":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3696,7 +3696,7 @@
       "Contest Effect":"Inversed Appeal",
       "Crits On":20
    },
-   "Double Hit":{  
+   "Double Hit":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"3",
@@ -3707,16 +3707,16 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Double Team":{  
+   "Double Team":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Illusion, Coat",
       "Effect":"The user gains 3 activations of Double Team. The user may either activate Double Team when being targeted by an attack to increase their Evasion by +2 against that attack or when making an attack to increase their Accuracy by +2 for that attack.",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable",
+      "Contest Effect":"Reliable"
    },
-   "Double-Edge":{  
+   "Double-Edge":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -3727,7 +3727,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Double Slap":{  
+   "Double Slap":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"4",
@@ -3738,7 +3738,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Echoed Voice":{  
+   "Echoed Voice":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3750,7 +3750,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Egg Bomb":{  
+   "Egg Bomb":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"6",
@@ -3761,7 +3761,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Encore":{  
+   "Encore":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -3769,9 +3769,9 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Roll 1d6. On a result of 1 or 2, the target becomes Confused; on a result of 3 or 4 the target becomes Suppressed; on a result of 5 or 6 the target becomes Enraged.",
       "Contest Type":"Cute",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Endeavor":{  
+   "Endeavor":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -3783,16 +3783,16 @@
       "Contest Effect":"Double TIme",
       "Crits On":20
    },
-   "Endure":{  
+   "Endure":{
       "Type":"Normal",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"Self, Reaction, Trigger",
       "Effect":"If the user is hit by a damaging Move, you may use Endure as a Free Action. If the Move would bring Endure's user down to 0 HP or less, Endure's user instead is set to 1 HP.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Entrainment":{  
+   "Entrainment":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -3800,9 +3800,9 @@
       "Range":"4, 1 Target",
       "Effect":"The target gains one of the user's Abilities for 3 turns.",
       "Contest Type":"Cute",
-      "Contest Effect":" Catching Up",
+      "Contest Effect":" Catching Up"
    },
-   "Explosion":{  
+   "Explosion":{
       "Type":"Normal",
       "Freq":"Daily",
       "AC":"2",
@@ -3814,7 +3814,7 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Extreme Speed":{  
+   "Extreme Speed":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3825,7 +3825,7 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Facade":{  
+   "Facade":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3837,7 +3837,7 @@
       "Contest Effect":"Double Time",
       "Crits On":20
    },
-   "Façade":{  
+   "Façade":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3849,7 +3849,7 @@
       "Contest Effect":"Double Time",
       "Crits On":20
    },
-   "Fake Out":{  
+   "Fake Out":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3861,7 +3861,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "False Swipe":{  
+   "False Swipe":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3873,16 +3873,16 @@
       "Contest Effect":"Inversed Appeal",
       "Crits On":20
    },
-   "Feint":{  
+   "Feint":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Trigger",
       "Effect":"If a foe uses a Move with the Shield Keyword in response to one of your actions, you may activate Feint to cause the triggering Move to Fail. Feint is activated as a Free Action.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Flail":{  
+   "Flail":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3894,7 +3894,7 @@
       "Contest Effect":"Double Time",
       "Crits On":20
    },
-   "Flash":{  
+   "Flash":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -3902,36 +3902,36 @@
       "Range":"Cone 2",
       "Effect":"Lower the Accuracy of all legal targets by -1. *Grants Glow",
       "Contest Type":"Beauty",
-      "Contest Effect":" Unsettling",
+      "Contest Effect":" Unsettling"
    },
-   "Focus Energy":{  
+   "Focus Energy":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user becomes Pumped. While Pumped, the user's Critical Range is extended by 2, or 18+ if the Critical Range is not otherwise extended. Being switched will cause this effect to end.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Follow Me":{  
+   "Follow Me":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 5, Social",
       "Effect":"Until the end of the user's next turn, all Foes must target the user when using a Move that targets their opponents. This effect ends if the user is Fainted or Switched out.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Foresight":{  
+   "Foresight":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self, Swift Action",
       "Effect":"Foresight may be activated as a Swift Action on the user’s turn. For the rest of the turn, the user’s Normal-Type and Fighting-Type Moves can hit and affect Ghost-Type targets, and the user can see through the Illusion Ability, Moves with the Illusion keyword, and effects created by the Illusionist Capability, ignoring all effects from those.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Frustration":{  
+   "Frustration":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3943,7 +3943,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Fury Attack":{  
+   "Fury Attack":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"4",
@@ -3954,7 +3954,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Fury Swipes":{  
+   "Fury Swipes":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"5",
@@ -3965,7 +3965,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Giga Impact":{  
+   "Giga Impact":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "AC":"4",
@@ -3976,7 +3976,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Glare":{  
+   "Glare":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -3984,9 +3984,9 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Glare Paralyzes the target.",
       "Contest Type":"Tough",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Growl":{  
+   "Growl":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -3994,36 +3994,36 @@
       "Range":"Burst 1, Friendly, Sonic, Social",
       "Effect":"Lower the Attack of all legal targets by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Growth":{  
+   "Growth":{
       "Type":"Normal",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Attack and Special Attack by +1 CS each. If it is Sunny, double the amount of Combat Stages gained. *Grants Inflatable",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Guillotine":{  
+   "Guillotine":{
       "Type":"Normal",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"Melee, 1 Target, Execute",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level.",
       "Contest Type":"Cool",
-      "Contest Effect":"Big Show",
+      "Contest Effect":"Big Show"
    },
-   "Harden":{  
+   "Harden":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Defense by +1 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Headbutt":{  
+   "Headbutt":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4035,7 +4035,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Head Charge":{  
+   "Head Charge":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -4047,25 +4047,25 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Heal Bell":{  
+   "Heal Bell":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 3, Sonic",
       "Effect":"All targets are cured of any Persistent Status ailments.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Helping Hand":{  
+   "Helping Hand":{
       "Type":"Normal",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"4, 1 Target, Priority",
       "Effect":"Helping Hand grants the target +2 on its next Accuracy Roll this round, and +10 to its next Damage Roll this round.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Hidden Power":{  
+   "Hidden Power":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4077,16 +4077,16 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hold Hands":{  
+   "Hold Hands":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"Both the user and the target become Cheered. They may give up the Cheered condition when making a Save Check to roll twice and take the best result.",
       "Contest Type":"?",
-      "Contest Effect":"?",
+      "Contest Effect":"?"
    },
-   "Horn Attack":{  
+   "Horn Attack":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4097,25 +4097,25 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Horn Drill":{  
+   "Horn Drill":{
       "Type":"Normal",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"Melee, 1 Target, Execute",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level.",
       "Contest Type":"Cool",
-      "Contest Effect":"Big Show",
+      "Contest Effect":"Big Show"
    },
-   "Howl":{  
+   "Howl":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack by +1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Hyper Beam":{  
+   "Hyper Beam":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "AC":"4",
@@ -4126,7 +4126,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Hyper Fang":{  
+   "Hyper Fang":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"4",
@@ -4138,7 +4138,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Hyper Voice":{  
+   "Hyper Voice":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -4150,7 +4150,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Judgement":{  
+   "Judgement":{
       "Type":"Normal",
       "Freq":"Daily",
       "AC":"2",
@@ -4162,7 +4162,7 @@
       "Contest Effect":"Tease",
       "Crits On":20
    },
-   "Last Resort":{  
+   "Last Resort":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4174,7 +4174,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Leer":{  
+   "Leer":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4182,18 +4182,18 @@
       "Range":"Cone 2, Friendly, Social",
       "Effect":"All legal targets have their Defense lowered by -1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Lock-On":{  
+   "Lock-On":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"10, 1 Target",
       "Effect":"The target is Locked-On. The next Move that the user uses against the Target that requires an Accuracy Check cannot miss. Lock-On's effect, on both the User and Target, can be passed by Baton Pass.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Lovely Kiss":{  
+   "Lovely Kiss":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"6",
@@ -4201,36 +4201,36 @@
       "Range":"6, 1 Target, Social",
       "Effect":"The target fall Asleep.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Lucky Chant":{  
+   "Lucky Chant":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Blessing",
       "Effect":"Any user affected by Lucky Chant may activate it when receiving a Critical Hit to cause the attack to instead deal damage as if it was not a Critical Hit. Lucky Chant may be activated 3 times and then disappears.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Me First":{  
+   "Me First":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Trigger, Interrupt",
       "Effect":"If an opponent declares a Damaging Attack against the user, and Me First’s user has a higher Speed stat then the target, the user may use Me First as an Interrupt. The User will then use the same Move the triggering foe was about to use on that foe.",
       "Contest Type":"Cute",
-      "Contest Effect":"Saving Grace",
+      "Contest Effect":"Saving Grace"
    },
-   "Mean Look":{  
+   "Mean Look":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"6, 1 Target, Social",
       "Effect":"The Target becomes Trapped and Slowed for the remainder of the encounter.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Mega Kick":{  
+   "Mega Kick":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"6",
@@ -4242,7 +4242,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Mega Punch":{  
+   "Mega Punch":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"4",
@@ -4253,61 +4253,61 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Metronome":{  
+   "Metronome":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Metronome randomly uses any other Move except for After You, Assist, Bestow, Copycat, Counter, Covet, Crafty Shield, Destiny Bond, Detect, Endure, Feint, Focus Punch, Follow Me, Helping Hand, King’s Shield, Metronome, Me First, Mimic, Mirror Coat, Mirror Move, Protect, Quash, Quick Guard, Rage Powder, Sketch, Sleep Talk, Snatch, Snore, Spiky Shield, Switcheroo, Thief, Transform, Trick, and Wide Guard. The GM helps to pick the random Move.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Milk Drink":{  
+   "Milk Drink":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The target regains HP equal to half of its full HP. The user may target themselves with Milk Drink.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Mimic":{  
+   "Mimic":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"6, 1 Target",
       "Effect":"Choose a Move that the target has used during the encounter. For the remainder of the encounter, that Move replaces Mimic on the user’s Move List. Mimic cannot miss.",
       "Contest Type":"Cute",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Mind Reader":{  
+   "Mind Reader":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"6, 1 Target",
       "Effect":"The target becomes Read to the user until the end of the user’s next turn. The user may end this effect when making an Attack on the user, causing that attack to automatically hit; OR when the Read target uses an Attack against the user, causing that attack to automatically miss. If the user has the Telepathy Capability, the user automatically succeeds on a mindreading attempt against the target, and may listen to the target’s surface thoughts as long as they remain Read. Mind Reader automatically misses against targets with the Mindlock Capability.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Minimize":{  
+   "Minimize":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user gains +4 Evasion, and the user's size is lowered to Small for the remainder of the encounter. *Grants Shrinkable",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Morning Sun":{  
+   "Morning Sun":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user regains Hit Points equal to half of its full Hit Point value. If it is Sunny, the user gains 2/3 of its full Hit Point value. If it is Rainy, Sand Storming or Hailing the user gains 1/4 of their full Hit Point value.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Natural Gift":{  
+   "Natural Gift":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -4319,7 +4319,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Nature Power":{  
+   "Nature Power":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"See Effect",
@@ -4328,9 +4328,9 @@
       "Range":"See Effect",
       "Effect":"Nature Power uses a Move defined by the Environ keyword.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Noble Roar":{  
+   "Noble Roar":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4338,27 +4338,27 @@
       "Range":"Burst 1, Sonic, Friendly, Social",
       "Effect":"Noble Roar lowers all legal targets’ Attack and Special Attack by +1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Odor Sleuth":{  
+   "Odor Sleuth":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self, Swift Action",
       "Effect":"Odor Sleuth may be activated as a Swift Action on the user’s turn. For the rest of the turn, the user’s Normal-Type and Fighting-Type Moves can hit and affect Ghost-Type targets, and the user can see through the Illusion Ability, Moves with the Illusion keyword, and effects created by the Illusionist Capability, ignoring all effects from those.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Pain Split":{  
+   "Pain Split":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"4, 1 Target",
       "Effect":"The user and the target both lose 1/2 of their current Hit Points. Add the amount of Hit Points the user and the target lost together, and divide the value by 2. Both the target and the user gain Hit Points equal to this value. Do not add Injuries from Pain Split from Hit Point Markers until the full effect of the Move has been resolved. Pain Split never causes Massive Damage. Hit Point loss from Pain Split cannot be prevented in any way.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Pay Day":{  
+   "Pay Day":{
       "Type":"Normal",
       "Freq":"Daily",
       "AC":"2",
@@ -4370,16 +4370,16 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Perish Song":{  
+   "Perish Song":{
       "Type":"Normal",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"Burst 15, Sonic",
       "Effect":"Perish Song cannot miss. All targets, including the user, receive a Perish Count of 3. At the beginning of each of the target’s turns, their Perish count is lowered by 1. Once a Perish Count reaches 0, set the Pokémon’s Hit Points to 0. A Perish Count disappears if a target returns to their Poké Ball, Takes a Breather, or is knocked out. Perish Song never causes Massive Damage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Play Nice":{  
+   "Play Nice":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4387,9 +4387,9 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Play Nice lowers the target’s Attack by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Pound":{  
+   "Pound":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4400,7 +4400,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Present":{  
+   "Present":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"3",
@@ -4412,25 +4412,25 @@
       "Contest Effect":"Inversed Appeal",
       "Crits On":20
    },
-   "Protect":{  
+   "Protect":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Interrupt, Shield, Trigger",
       "Effect":"If the user is hit by a Move, the user may use Protect. The user is instead not hit by the Move. The user does not take any damage nor is affected by any of the Move's effects.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Psych Up":{  
+   "Psych Up":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"6, 1 Target",
       "Effect":"The user's Combat Stages are changed to match the target's Combat Stages. Psych Up cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Quick Attack":{  
+   "Quick Attack":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4441,7 +4441,7 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Rage":{  
+   "Rage":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4453,7 +4453,7 @@
       "Contest Effect":"Get Ready!",
       "Crits On":20
    },
-   "Rapid Spin":{  
+   "Rapid Spin":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4465,7 +4465,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Razor Wind":{  
+   "Razor Wind":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4477,25 +4477,25 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Recover":{  
+   "Recover":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Recycle":{  
+   "Recycle":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The effect of a consumable item used earlier in the encounter is used again as if it had not been destroyed. The item is still gone.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Reflect Type":{  
+   "Reflect Type":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -4503,18 +4503,18 @@
       "Range":"Melee, 1 Target",
       "Effect":"Reflect Type changes one of the user’s Types into one Type of your choice that the target has for the rest of the scene.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Refresh":{  
+   "Refresh":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user is cured of all Poison, Burns, and Paralysis.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Relic Song":{  
+   "Relic Song":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -4526,7 +4526,7 @@
       "Contest Effect":"Excitement",
       "Crits On":20
    },
-   "Retaliate":{  
+   "Retaliate":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -4538,7 +4538,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Return":{  
+   "Return":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4550,7 +4550,7 @@
       "Contest Effect":" Exhausting Act",
       "Crits On":20
    },
-   "Roar":{  
+   "Roar":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -4558,9 +4558,9 @@
       "Range":"Burst 1, Sonic, Social",
       "Effect":"When declaring Roar, the user does nothing. At the end of the round, the user Shifts and uses Roar. Targets hit by Roar immediately Shift away from the user using their highest useable movement capability, towards their Trainer if possible. If the target is an owned Pokémon and ends this shift within 6 meters of their Poké Ball, they are immediately recalled to their Poké Ball. If that Trainer sends out a replacement, they do not lose their Command action.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Rock Climb":{  
+   "Rock Climb":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"5",
@@ -4572,7 +4572,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Round":{  
+   "Round":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4584,16 +4584,16 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Safeguard":{  
+   "Safeguard":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Blessing",
       "Effect":"Blessing – Any user affected by Safeguard may activate it when receiving a Status Affliction to ignore the effects of that Status Affliction on their next turn. Safeguard may be activated 3 times, and then disappears.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Scary Face":{  
+   "Scary Face":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4601,9 +4601,9 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Lower the target’s Speed by -2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation",
+      "Contest Effect":"Desperation"
    },
-   "Scratch":{  
+   "Scratch":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4614,7 +4614,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Screech":{  
+   "Screech":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"4",
@@ -4622,9 +4622,9 @@
       "Range":"Burst 2, Friendly, Sonic",
       "Effect":"Lower the Defense of all legal targets by -2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Secret Power":{  
+   "Secret Power":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4636,7 +4636,7 @@
       "Contest Effect":"Tease",
       "Crits On":20
    },
-   "Self-Destruct":{  
+   "Self-Destruct":{
       "Type":"Normal",
       "Freq":"Daily",
       "AC":"2",
@@ -4648,25 +4648,25 @@
       "Contest Effect":"Big Show",
       "Crits On":20
    },
-   "Sharpen":{  
+   "Sharpen":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack by +1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Shell Smash":{  
+   "Shell Smash":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Attack, Special Attack, and Speed by +2 CS each. Lower the user's Defense and Special Defense by -1 CS each.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Simple Beam":{  
+   "Simple Beam":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -4674,9 +4674,9 @@
       "Range":"6, 1 Target",
       "Effect":"You choose one of the target's Abilities. Simple Beam changes that Ability to Simple for the remainder of the encounter.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance",
+      "Contest Effect":"Steady Performance"
    },
-   "Sing":{  
+   "Sing":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"10",
@@ -4684,18 +4684,18 @@
       "Range":"Burst 2, Friendly, Sonic",
       "Effect":"All legal Targets fall Asleep. On a miss, Sing instead causes targets to become Slowed and suffer a -2 penalty to their Evasion until the end of the user's next turn.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Sketch":{  
+   "Sketch":{
       "Type":"Normal",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"15, 1 Target",
       "Effect":"Sketch cannot miss. Once Sketch has been used, remove Sketch from the user's Move list. The last Move that the target used is added to the user's Move list permanently. Sketch may not be Interrupted or Intercepted.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up",
+      "Contest Effect":" Catching Up"
    },
-   "Skull Bash":{  
+   "Skull Bash":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -4707,16 +4707,16 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Slack Off":{  
+   "Slack Off":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Slam":{  
+   "Slam":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"6",
@@ -4728,7 +4728,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Slash":{  
+   "Slash":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4740,16 +4740,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":18
    },
-   "Sleep Talk":{  
+   "Sleep Talk":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Select another of the user’s Moves at random; this turn, the user may Shift and use that Move despite being Asleep. Sleep Talk can be only be used by Sleeping targets.",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance",
+      "Contest Effect":"Steady Performance"
    },
-   "Smelling Salts":{  
+   "Smelling Salts":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -4761,16 +4761,16 @@
       "Contest Effect":"Unsettling",
       "Crits On":20
    },
-   "Smokescreen":{  
+   "Smokescreen":{
       "Type":"Normal",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"5, Ranged Blast 3",
       "Effect":"Smokescreen creates a blast of Smoke that covers the target area; the Smoke persists until the end of the encounter, or until Defog or Whirlwind are used. All targets attacking from or into the Smoke receive a -3 penalty to Accuracy.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Snore":{  
+   "Snore":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4782,16 +4782,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Soft-Boiled":{  
+   "Soft-Boiled":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The target regains Hit Points equal to half of its full Hit Points. The user may target themselves with Soft-Boiled.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Sonic Boom":{  
+   "Sonic Boom":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"6",
@@ -4803,7 +4803,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Spike Cannon":{  
+   "Spike Cannon":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"4",
@@ -4814,7 +4814,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Spit Up":{  
+   "Spit Up":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -4826,25 +4826,25 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Splash":{  
+   "Splash":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Shift Action - The user may make a single Jump, adding +1 to their Long Jump and High Jump values, and gains +2 Evasion until the end of their next turn. *Grants +1 Long Jump",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Stockpile":{  
+   "Stockpile":{
       "Type":"Normal",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user adds 1 to their Stockpiled count to a maximum of 3. For each number a Stockpiled count is above 0, raise the user’s Defense and Special Defense by +1 CS each. If a Stockpiled count is set to 0, any Combat Stages gained from the Stockpiled count are removed.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Stomp":{  
+   "Stomp":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4856,7 +4856,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Strength":{  
+   "Strength":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -4868,16 +4868,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Substitute":{  
+   "Substitute":{
       "Type":"Normal",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Illusion, Coat",
       "Effect":"The user loses 1/4 of their maximum Hit Points. This Hit Point loss cannot be prevented in any way. The user creates an Illusory Substitute Coat, which has Hit Points equal to 1/4th of the user’s full Hit Points +1. If the user would be hit by a Move or attack, instead the Substitute gets hit. Apply weakness, resistance and stats to the Substitute. The Substitute is immune to Status Afflictions and Status Moves. Moves with the Social or Sonic keywords completely ignore and bypass the Substitute. Once the Substitute has been destroyed, the user may be hit as normal. Substitute cannot be used if the user has less than 1/4 of their full Hit Points.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up",
+      "Contest Effect":" Catching Up"
    },
-   "Super Fang":{  
+   "Super Fang":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"4",
@@ -4889,7 +4889,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Supersonic":{  
+   "Supersonic":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"6",
@@ -4897,9 +4897,9 @@
       "Range":"4, 1 Target, Sonic",
       "Effect":"The target becomes Confused. On miss, the target suffers a -2 penalty to Accuracy Rolls for one full round.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Swagger":{  
+   "Swagger":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"4",
@@ -4907,18 +4907,18 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Raise the target's Attack by +2 CS. The target is Confused.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Swallow":{  
+   "Swallow":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"If the user’s Stockpiled count is 1, they are healed 25% of their full Hit Point value; if their Stockpiled count is 2, they are healed half of their full Hit Point value; if their Stockpiled count is 3, they are healed back to full Hit Points. After using Swallow, the user’s Stockpiled count is set to 0. If the user has no Stockpiled count, Swallow does nothing.",
       "Contest Type":"Tough",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Sweet Scent":{  
+   "Sweet Scent":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -4926,9 +4926,9 @@
       "Range":"Burst 2, Friendly",
       "Effect":"Targets hit by Sweet Scent gain a -2 Penalty to Evasion. (Total Evasion may not be lowered to a negative value.) *Grants Alluring",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Swift":{  
+   "Swift":{
       "Type":"Normal",
       "Freq":"EOT",
       "DB":"6",
@@ -4939,16 +4939,16 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Swords Dance":{  
+   "Swords Dance":{
       "Type":"Normal",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Attack by +2 CS.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Tackle":{  
+   "Tackle":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4960,7 +4960,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Tail Slap":{  
+   "Tail Slap":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"4",
@@ -4971,7 +4971,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Tail Whip":{  
+   "Tail Whip":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -4979,9 +4979,9 @@
       "Range":"Burst 1, Friendly",
       "Effect":"All legal targets have their Defense lowered by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Take Down":{  
+   "Take Down":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"5",
@@ -4993,7 +4993,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Techno Blast":{  
+   "Techno Blast":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -5005,7 +5005,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Teeter Dance":{  
+   "Teeter Dance":{
       "Type":"Normal",
       "Freq":"Scene",
       "AC":"2",
@@ -5013,9 +5013,9 @@
       "Range":"Burst 1",
       "Effect":"All legal targets are Confused.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Thrash":{  
+   "Thrash":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"3",
@@ -5027,7 +5027,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Tickle":{  
+   "Tickle":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -5035,18 +5035,18 @@
       "Range":"Melee, 1 Target",
       "Effect":"Lower the target’s Attack and Defense by -1 CS each.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Transform":{  
+   "Transform":{
       "Type":"Normal",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"10, 1 Target",
       "Effect":"The user targets a Pokémon within 10 meters and assumes the form of the target. It gains all of the target's Moves, Abilities, and Capabilities; and copies its weight and height. Transform lasts until the user is switched out, Fainted, or until the end of the encounter. The user may choose to end the Transformation on its turn as a free action, regaining its previous Move List. The user's Stats do not change from using Transform. Transform cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up",
+      "Contest Effect":" Catching Up"
    },
-   "Tri Attack":{  
+   "Tri Attack":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -5058,7 +5058,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Trump Card":{  
+   "Trump Card":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -5070,7 +5070,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Uproar":{  
+   "Uproar":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -5082,7 +5082,7 @@
       "Contest Effect":"Unsettling",
       "Crits On":20
    },
-   "Vicegrip":{  
+   "Vicegrip":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"2",
@@ -5093,7 +5093,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Weather Ball":{  
+   "Weather Ball":{
       "Type":"Normal",
       "Freq":"EOT",
       "AC":"2",
@@ -5105,7 +5105,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Whirlwind":{  
+   "Whirlwind":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -5113,27 +5113,27 @@
       "Range":"Line 6",
       "Effect":"All targets are pushed X meters, where X is 8 minus their weight class. If the Line targets into a Smokescreen, the smoke is dispersed. All hazards in the Whirlwind are destroyed.",
       "Contest Type":"Smart",
-      "Contest Effect":"Big Show",
+      "Contest Effect":"Big Show"
    },
-   "Wish":{  
+   "Wish":{
       "Type":"Normal",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"15, 1 Target",
       "Effect":"At the end of the user's next turn, the target regains HP equal to half of its full HP. If the user targets itself and is replaced in battle, the replacement is healed by half of its own HP.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Work Up":{  
+   "Work Up":{
       "Type":"Normal",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Special Attack by +1 CS each.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Wrap":{  
+   "Wrap":{
       "Type":"Normal",
       "Freq":"Static",
       "Class":"Static",
@@ -5143,7 +5143,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Wring Out":{  
+   "Wring Out":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "AC":"2",
@@ -5155,16 +5155,16 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Yawn":{  
+   "Yawn":{
       "Type":"Normal",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"2, 1 Target, Social",
       "Effect":"The target falls Asleep at the end of its next turn. Yawn cannot miss.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Acid":{  
+   "Acid":{
       "Type":"Poison",
       "Freq":"At-Will",
       "AC":"2",
@@ -5176,16 +5176,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Acid Armor":{  
+   "Acid Armor":{
       "Type":"Poison",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Set-Up",
       "Effect":"Set-Up Effect: The user becomes Liquefied. While Liquefied, the user is Slowed and cannot take Standard Actions except to Resolve the effect of Acid Armor, the user's Movement is never obstructed by rough or slow terrain, and the user can shift even through the smallest openings. Furthermore, while Liquefied, the user is completely immune to all Physical damage and becomes completely invisible if fully submerged in any liquid. Resolution Effect: The user gains +1 Defense CS, then stops being liquified.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Acid Spray":{  
+   "Acid Spray":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"2",
@@ -5197,7 +5197,7 @@
       "Contest Effect":"Unsettling",
       "Crits On":20
    },
-   "Belch":{  
+   "Belch":{
       "Type":"Poison",
       "Freq":"Scene x2",
       "AC":"4",
@@ -5209,7 +5209,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Clear Smog":{  
+   "Clear Smog":{
       "Type":"Poison",
       "Freq":"Scene x2",
       "DB":"5",
@@ -5220,16 +5220,16 @@
       "Contest Effect":"Sabotage",
       "Crits On":20
    },
-   "Coil":{  
+   "Coil":{
       "Type":"Poison",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Defense by +1 CS, and the user gains +1 Accuracy.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Cross Poison":{  
+   "Cross Poison":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"2",
@@ -5241,7 +5241,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":18
    },
-   "Gastro Acid":{  
+   "Gastro Acid":{
       "Type":"Poison",
       "Freq":"Scene",
       "AC":"2",
@@ -5249,9 +5249,9 @@
       "Range":"4. 1 Target",
       "Effect":"The target's Ability is disabled until the end of the encounter. If the target has more than one ability, you choose one of them to disable.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Gunk Shot":{  
+   "Gunk Shot":{
       "Type":"Poison",
       "Freq":"Daily x2",
       "AC":"5",
@@ -5263,7 +5263,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Poison Fang":{  
+   "Poison Fang":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"2",
@@ -5275,7 +5275,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Poison Gas":{  
+   "Poison Gas":{
       "Type":"Poison",
       "Freq":"Scene",
       "AC":"6",
@@ -5283,9 +5283,9 @@
       "Range":"Burst 1 or Cone 2",
       "Effect":"Poison Gas Poisons all legal targets.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance",
+      "Contest Effect":"Steady Performance"
    },
-   "Poison Jab":{  
+   "Poison Jab":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"2",
@@ -5297,7 +5297,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Poison Powder":{  
+   "Poison Powder":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"6",
@@ -5305,9 +5305,9 @@
       "Range":"4, 1 Target, Powder",
       "Effect":"The target is Poisoned.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Poison Sting":{  
+   "Poison Sting":{
       "Type":"Poison",
       "Freq":"At-Will",
       "AC":"2",
@@ -5319,7 +5319,7 @@
       "Contest Effect":"Excitement",
       "Crits On":20
    },
-   "Poison Tail":{  
+   "Poison Tail":{
       "Type":"Poison",
       "Freq":"At-Will",
       "AC":"2",
@@ -5331,7 +5331,7 @@
       "Contest Effect":"Incentives",
       "Crits On":18
    },
-   "Sludge":{  
+   "Sludge":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"2",
@@ -5343,7 +5343,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Sludge Bomb":{  
+   "Sludge Bomb":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"2",
@@ -5355,7 +5355,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Sludge Wave":{  
+   "Sludge Wave":{
       "Type":"Poison",
       "Freq":"Scene x2",
       "AC":"2",
@@ -5367,7 +5367,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Smog":{  
+   "Smog":{
       "Type":"Poison",
       "Freq":"At-Will",
       "AC":"7",
@@ -5379,7 +5379,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Toxic":{  
+   "Toxic":{
       "Type":"Poison",
       "Freq":"Scene x2",
       "AC":"4",
@@ -5387,27 +5387,27 @@
       "Range":"4, 1 Target",
       "Effect":"The target is Badly Poisoned. If the user is Poison Type, Toxic cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Toxic Spikes":{  
+   "Toxic Spikes":{
       "Type":"Poison",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"6, Hazard",
       "Effect":"Set 8 square meters of Toxic Spikes within the range such that all 8 meters are adjacent with at least one other space of Toxic Spikes. Toxic Spikes cause Terrain to become Slow Terrain, and a grounded foe that runs into the hazard becomes Poisoned and Slowed until the end of their next turn. If there are 2 layers of Toxic Spikes on the same space, it Badly Poisons the foes instead. Poison-Type Pokémon may move over Toxic Spikes harmlessly, destroying the Hazards as they do so.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Venom Drench":{  
+   "Venom Drench":{
       "Type":"Poison",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Cone 2",
       "Effect":"All Poisoned targets have their Attack, Special Attack, and Speed lowered by -1 CS. Venom Drench cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Venoshock":{  
+   "Venoshock":{
       "Type":"Poison",
       "Freq":"Scene x2",
       "AC":"2",
@@ -5419,52 +5419,52 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Agility":{  
+   "Agility":{
       "Type":"Psychic",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Speed 2 Combat Stages.",
       "Contest Type":"Cool",
-      "Contest Effect":"Saving Grace",
+      "Contest Effect":"Saving Grace"
    },
-   "Ally Switch":{  
+   "Ally Switch":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"6, 1 Target, Interrupt",
       "Effect":"Ally Switch may be declared during a foe’s turn as an Interrupt. The user chooses one willing ally within 6 meters; the target and the user switch places. If the ally was a target of a Move, the user is now the target; If the user was a target of a Move, the ally is now the target.",
       "Contest Type":"Cool",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Amnesia":{  
+   "Amnesia":{
       "Type":"Psychic",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Special Defense 2 Combat Stages.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Barrier":{  
+   "Barrier":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Hazard",
       "Effect":"The user creates a Barrier of psychic energy. The user places up to 4 segments of Barrier; each segment must be continuous with another segment, and at least one must be adjacent to the user. These barriers count as blocking terrain and last until the end of the encounter or until they are destroyed. Each Barrier segment is 2 meters tall, 1 meter wide, and 2 centimeters thick. Each segment has 20 Hit Points, 15 Damage Reduction, and takes damage as if it was Psychic Typed.",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Calm Mind":{  
+   "Calm Mind":{
       "Type":"Psychic",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Special Attack 1 Combat Stage and raise the user’s Special Defense 1 Combat Stage.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Confusion":{  
+   "Confusion":{
       "Type":"Psychic",
       "Freq":"At-Will",
       "AC":"2",
@@ -5476,16 +5476,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Cosmic Power":{  
+   "Cosmic Power":{
       "Type":"Psychic",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Defense 1 Combat Stage and raise the user’s Special Defense 1 Combat Stage.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Dream Eater":{  
+   "Dream Eater":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -5497,7 +5497,7 @@
       "Contest Effect":" Good Show!",
       "Crits On":20
    },
-   "Extrasensory":{  
+   "Extrasensory":{
       "Type":"Psychic",
       "Freq":"At-Will",
       "AC":"2",
@@ -5509,7 +5509,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Future Sight":{  
+   "Future Sight":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "DB":"12",
@@ -5520,34 +5520,34 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Gravity":{  
+   "Gravity":{
       "Type":"Psychic",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"For 5 rounds, the area is considered Warped. While Warped, Moves that involve the user being airborne may not be used. Pokémon cannot use Sky or Levitate Capabilities to end their turn at an altitude higher than 1 meter. Flying-Types and Pokémon with the Ability Levitate are no longer immune to Ground-Type Moves. All Accuracy Rolls receive a +2 Bonus.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Guard Split":{  
+   "Guard Split":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The target loses 5 Defense and 5 Special Defense. If they do, the user gains 5 Damage Reduction. These effects last until the end of the Scene.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Guard Swap":{  
+   "Guard Swap":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The user and the target trade Combat Stage values for the Defense Stat, and then for the Special Defense Stat.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Heal Block":{  
+   "Heal Block":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -5555,27 +5555,27 @@
       "Range":"6, 1 Target",
       "Effect":"Until the end of the encounter, the target may not gain HP or Temporary HP from any source. This effect ends if the target is switched out or Takes a Breather.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Healing Wish":{  
+   "Healing Wish":{
       "Type":"Psychic",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"6, 1 Target",
       "Effect":"The user immediately Faints, lowering its HP to 0. The user takes no Injuries from HP Markers when using Healing Wish. The target is immediately cured of up to 3 injuries, healed to their Maximum Hit Points, and has the Frequency of all Moves restored. Healing Wish may target a Pokémon in a Poké Ball. Healing Wish does not restore the Frequency of Healing Wish or Lunar Dance. Injuries healed through Healing Wish count toward the total number of Injuries that can be healed each day, and this healing is limited by the same.",
       "Contest Type":"Cute",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Heal Pulse":{  
+   "Heal Pulse":{
       "Type":"Psychic",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"6, 1 Target, Aura",
       "Effect":"Restores 50% of the target’s max Hit Points. Heal Pulse’s user may not target itself with Heal Pulse.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Heart Stamp":{  
+   "Heart Stamp":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -5587,16 +5587,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Heart Swap":{  
+   "Heart Swap":{
       "Type":"Psychic",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"10, 2 Targets",
       "Effect":"The targets trade Combat Stage values for each stat.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Hypnosis":{  
+   "Hypnosis":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "AC":"6",
@@ -5604,45 +5604,45 @@
       "Range":"4, 1 Target",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Imprison":{  
+   "Imprison":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"10, 1 Target",
       "Effect":"The target is Locked for the rest of the Scene. A Locked target may not use any Moves the user knows. Imprison cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Kinesis":{  
+   "Kinesis":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"6, 1 Target, Trigger, Interrupt",
       "Effect":"If the user or an Ally within 6 meters is about to be hit by an attack, the user may use Kinesis as an interrupt. The triggering Accuracy Roll receives a -4 penalty. This may cause Moves to miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Light Screen":{  
+   "Light Screen":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Blessing",
       "Effect":"Blessing – Any user affected by Light Screen may activate it when receiving Special Damage to resist the Damage one step. Light Screen may be activated 2 times, and then disappears.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Lunar Dance":{  
+   "Lunar Dance":{
       "Type":"Psychic",
       "Freq":"Daily",
       "Class":"Status",
       "Range":8,
       "Effect":"The user immediately Faints, lowering its Hit Points to 0. The user takes no Injuries from Hit Point Markers when using Lunar Dance. The target is immediately cured of up to 3 injuries, healed to their Maximum Hit Points, and has the Frequency of all Moves restored. Lunar Dance may target a Pokémon in a Poké Ball. Lunar Dance does not restore the Frequency of Healing Wish or Lunar Dance. Injuries healed through Lunar Dance count toward the total number of Injuries that can be healed each day, and this healing is limited by the same.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Luster Purge":{  
+   "Luster Purge":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "AC":"2",
@@ -5654,52 +5654,52 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Magic Coat":{  
+   "Magic Coat":{
       "Type":"Psychic",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"4, Interrupt, Trigger",
       "Effect":"If the user is about to get a hit by a Move that does not have a Damage Dice Roll, they may use Magic Coat as an Interrupt. The Interrupted Move’s user is treated as if they were the target of their own Move, with the user of Magic Coat as the user.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double Time",
+      "Contest Effect":"Double Time"
    },
-   "Magic Room":{  
+   "Magic Room":{
       "Type":"Psychic",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"The area becomes Useless for 5 rounds. While Useless, Pokémon may not benefit from the effects of any Held Items, and Trainers cannot benefit from any Accessory-Slot equipment. This does not affect consumable or activated items, only Items with Static effects or Triggers.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Meditate":{  
+   "Meditate":{
       "Type":"Psychic",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack 1 Combat Stage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Miracle Eye":{  
+   "Miracle Eye":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self, Swift Action",
       "Effect":"Miracle Eye may be activated as a Swift Action on the user’s turn. For the rest of the turn, the user’s Psychic-Type Moves can hit and affect Dark-Type targets, and the user can see through the Illusion Ability, Moves with the Illusion keyword, and effects created by the Illusionist Capability, ignoring all effects from those.",
       "Contest Type":"Cute",
-      "Contest Effect":" Good Show!",
+      "Contest Effect":" Good Show!"
    },
-   "Mirror Coat":{  
+   "Mirror Coat":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Any, 1 Target, Reaction",
       "Effect":"Mirror Coat may be used as a Reaction when the user is hit by a damaging Special Attack. Resolve the Triggering Attack, with Mirror Coat’s user resisting the attack one step further. After the attack is resolved, if Mirror Coat’s user was not Fainted, the triggering foe then loses Hit Points equal to twice the amount of Hit Points lost by the user from the triggering attack. Note that Mirror Coat is Special, and while it cannot miss, it cannot hit targets immune to Psychic-Type Moves.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double Time",
+      "Contest Effect":"Double Time"
    },
-   "Mist Ball":{  
+   "Mist Ball":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "AC":"2",
@@ -5711,34 +5711,34 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Power Split":{  
+   "Power Split":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The target has their Attack and Special Attack lowered by 5. If they do, the user gains a +5 bonus to Damage Rolls. These effects last until the end of the scene.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Power Swap":{  
+   "Power Swap":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The user and the target trade Combat Stage values for the Attack Stat, and then for the Special Attack Stat.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Power Trick":{  
+   "Power Trick":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user's Attack stat and Defense stat are switched for the remainder of the encounter, or until the user is switched out or Fainted.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Psybeam":{  
+   "Psybeam":{
       "Type":"Psychic",
       "Freq":"At-Will",
       "AC":"2",
@@ -5750,7 +5750,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Psychic":{  
+   "Psychic":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -5762,7 +5762,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Psycho Boost":{  
+   "Psycho Boost":{
       "Type":"Psychic",
       "Freq":"Scene",
       "AC":"4",
@@ -5774,7 +5774,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Psycho Cut":{  
+   "Psycho Cut":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -5786,16 +5786,16 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":18
    },
-   "Psycho Shift":{  
+   "Psycho Shift":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The user is cured of a Status ailment and the target is given that Status ailment. Psycho Shift cannot miss. Psycho Shift can only be used if the user has a Status ailment and the target does not have the status ailment that is being transferred.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Psyshock":{  
+   "Psyshock":{
       "Type":"Psychic",
       "Freq":"At-Will",
       "AC":"2",
@@ -5807,7 +5807,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Psystrike":{  
+   "Psystrike":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -5819,7 +5819,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Psywave":{  
+   "Psywave":{
       "Type":"Psychic",
       "Freq":"Scene",
       "AC":"5",
@@ -5831,43 +5831,43 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Reflect":{  
+   "Reflect":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Blessing",
       "Effect":"Blessing – Any user affected by Reflect may activate it when receiving Physical Damage to resist the Damage one step. Reflect may be activated 2 times, and then disappears.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Rest":{  
+   "Rest":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self",
       "Effect":"The user is set to their full Hit Point value. The user is cured of any Status ailments. Then, the user falls Asleep. The user cannot make Sleep Checks at the beginning of their turn. They are cured of the Sleep at the end of their turn in 2 rounds.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal",
+      "Contest Effect":"Reflective Appeal"
    },
-   "Role Play":{  
+   "Role Play":{
       "Type":"Psychic",
       "Freq":"Daily",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The user gains one of the target's Abilities, chosen at random, for the remainder of the encounter. This effect ends if the user Faints or is switched out. Role Play cannot miss.",
       "Contest Type":"Cute",
-      "Contest Effect":" Catching Up",
+      "Contest Effect":" Catching Up"
    },
-   "Skill Swap":{  
+   "Skill Swap":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Melee, 1 Target",
       "Effect":"The user loses one of their Abilities, selected by the user, and gains one the target’s Abilities, selected at random, for the remainder of encounter. The target loses the copied Ability, and gains the user’s lost Ability. This effect ends if either the target or the user is Switched out or Fainted, but only for that Pokémon or Trainer.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement",
+      "Contest Effect":"Excitement"
    },
-   "Stored Power":{  
+   "Stored Power":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -5879,7 +5879,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Synchronoise":{  
+   "Synchronoise":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "AC":"2",
@@ -5891,25 +5891,25 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Telekinesis":{  
+   "Telekinesis":{
       "Type":"Psychic",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"4, 1 Target",
       "Effect":"The target becomes Lifted. While Lifted, they gain the Levitate Ability, are Slowed, and lose all Movement Capabilities except for the Levitate 4 granted by Levitate (reduced to 2 by the Slow condition). While Lifted, the user may not apply any Evasion bonuses to determine whether they are hit by Moves or not. The Lifted target may use a Shift Action to roll 1d20; on a result of 16+, they stop being Lifted. *Grants Telekinetic",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance",
+      "Contest Effect":"Steady Performance"
    },
-   "Teleport":{  
+   "Teleport":{
       "Type":"Psychic",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Interrupt",
       "Effect":"The user Teleports up to X meters, where X is its Teleporter Capability. Any Move that targeted Teleport's user continue through the desired target's space if the Move allows for it as if the user hadn't been there; single target moves simply miss. *Grants Teleporter 4",
       "Contest Type":"Cool",
-      "Contest Effect":"Saving Grace",
+      "Contest Effect":"Saving Grace"
    },
-   "Trick":{  
+   "Trick":{
       "Type":"Psychic",
       "Freq":"Scene",
       "AC":"2",
@@ -5917,27 +5917,27 @@
       "Range":"5, 2 Targets",
       "Effect":"Both targets must be hit for Trick to succeed. The user may target itself or willing allies with Trick; you do not need to roll for Accuracy Check in these cases. Both targets lose their Held Item and gain the other target's Held Item. If a target has no Held Item, they still can gain the other target's Held Item.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber",
+      "Contest Effect":"Attention Grabber"
    },
-   "Trick Room":{  
+   "Trick Room":{
       "Type":"Psychic",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"Starting at the beginning of the next round, for 5 rounds, the area is considered Rewinding. While Rewinding, Initiative is reversed, and participants instead go from lowest Initiative to highest.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Wonder Room":{  
+   "Wonder Room":{
       "Type":"Psychic",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field",
       "Effect":"For 5 rounds, the area is considered Wondered. While Wondered, each individual Pokémon's Defense and Special Defense are switched.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease",
+      "Contest Effect":"Tease"
    },
-   "Zen Headbutt":{  
+   "Zen Headbutt":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"4",
@@ -5949,7 +5949,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Ancient Power":{  
+   "Ancient Power":{
       "Type":"Rock",
       "Freq":"EOT",
       "AC":"2",
@@ -5961,7 +5961,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Diamond Storm":{  
+   "Diamond Storm":{
       "Type":"Rock",
       "Freq":"Scene",
       "AC":"3",
@@ -5973,7 +5973,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Head Smash":{  
+   "Head Smash":{
       "Type":"Rock",
       "Freq":"Scene",
       "AC":"5",
@@ -5985,7 +5985,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Power Gem":{  
+   "Power Gem":{
       "Type":"Rock",
       "Freq":"At-Will",
       "AC":"2",
@@ -5996,7 +5996,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Rock Blast":{  
+   "Rock Blast":{
       "Type":"Rock",
       "Freq":"EOT",
       "AC":"5",
@@ -6008,16 +6008,16 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Rock Polish":{  
+   "Rock Polish":{
       "Type":"Rock",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Speed by +2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Exhausting Act",
+      "Contest Effect":"Exhausting Act"
    },
-   "Rock Slide":{  
+   "Rock Slide":{
       "Type":"Rock",
       "Freq":"Scene x2",
       "AC":"4",
@@ -6029,7 +6029,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Rock Throw":{  
+   "Rock Throw":{
       "Type":"Rock",
       "Freq":"At-Will",
       "AC":"4",
@@ -6040,7 +6040,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Rock Tomb":{  
+   "Rock Tomb":{
       "Type":"Rock",
       "Freq":"At-Will",
       "AC":"5",
@@ -6052,7 +6052,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Rock Wrecker":{  
+   "Rock Wrecker":{
       "Type":"Rock",
       "Freq":"Daily x2",
       "AC":"4",
@@ -6064,7 +6064,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Rollout":{  
+   "Rollout":{
       "Type":"Rock",
       "Freq":"At-Will",
       "AC":"4",
@@ -6076,16 +6076,16 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Sandstorm":{  
+   "Sandstorm":{
       "Type":"Rock",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field, Weather",
       "Effect":"The weather changes to a Sandstorm for 5 rounds. While it is Sandstorming, all non-Ground, Rock, or Steel Type Pokémon lose a Tick of Hit Points at the beginning of their turn.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Smack Down":{  
+   "Smack Down":{
       "Type":"Rock",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6097,16 +6097,16 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Stealth Rock":{  
+   "Stealth Rock":{
       "Type":"Rock",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Field, Hazard",
       "Effect":"Set 4 square meters of Stealth Rock hazards within 6 meters. If a foe moves within 2 meters of a space occupied by Rocks, move at most one Rock to the offender, then destroy the Rock. When that happens, the Stealth Rock causes a foe to lose a Tick of Hit Points. Stealth Rock is considered to be dealing damage; Apply Weakness and Resistance. Do not apply stats. A Pokémon who has been hit by a Stealth Rock Hazard cannot get hit by another in the same encounter until it is returned to a Poké Ball and then sent back out. *Grants Materializer",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Stone Edge":{  
+   "Stone Edge":{
       "Type":"Rock",
       "Freq":"EOT",
       "AC":"5",
@@ -6118,25 +6118,25 @@
       "Contest Effect":"Incentives",
       "Crits On":17
    },
-   "Wide Guard":{  
+   "Wide Guard":{
       "Type":"Rock",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Burst 1, Interrupt, Shield, Trigger",
       "Effect":"If an Ally adjacent to Wide Guard’s user is hit by a Move, you may use Wide Guard as an Interrupt. All targets adjacent to Wide Guard’s user, including the user, are instead not hit by the triggering Move and do not suffer any of its effects.",
       "Contest Type":"Tough",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Autotomize":{  
+   "Autotomize":{
       "Type":"Steel",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"For the remainder of the Encounter, the user’s Weight Class is one value lower, to a minimum of 1. If the user can, the user’s Speed is raised by +2 Combat Stages.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Bullet Punch":{  
+   "Bullet Punch":{
       "Type":"Steel",
       "Freq":"At-Will",
       "AC":"2",
@@ -6147,7 +6147,7 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Doom Desire":{  
+   "Doom Desire":{
       "Type":"Steel",
       "Freq":"Scene x2",
       "DB":"14",
@@ -6158,7 +6158,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Flash Cannon":{  
+   "Flash Cannon":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"2",
@@ -6170,7 +6170,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Gear Grind":{  
+   "Gear Grind":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"3",
@@ -6181,7 +6181,7 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Gyro Ball":{  
+   "Gyro Ball":{
       "Type":"Steel",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6193,7 +6193,7 @@
       "Contest Effect":"Double Time",
       "Crits On":20
    },
-   "Heavy Slam":{  
+   "Heavy Slam":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"2",
@@ -6205,16 +6205,16 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Iron Defense":{  
+   "Iron Defense":{
       "Type":"Steel",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user's Defense by +2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Iron Head":{  
+   "Iron Head":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"2",
@@ -6226,7 +6226,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Iron Tail":{  
+   "Iron Tail":{
       "Type":"Steel",
       "Freq":"Scene x2",
       "AC":"6",
@@ -6238,16 +6238,16 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "King's Shield":{  
+   "King's Shield":{
       "Type":"Steel",
       "Freq":"Scene",
       "Class":"Status",
       "Range":" Self, Interrupt, Shield, Trigger",
       "Effect":" If the user is hit by an attack, the user may use King’s Shield. The user is instead not hit by the Move. You do not take any damage nor are you affected by any of the Move’s effects. In addition, if the triggering attack was Melee ranged, the attacker’s Attack is lowered by -2 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal",
+      "Contest Effect":"Inversed Appeal"
    },
-   "Magnet Bomb":{  
+   "Magnet Bomb":{
       "Type":"Steel",
       "Freq":"EOT",
       "DB":"6",
@@ -6258,7 +6258,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Metal Burst":{  
+   "Metal Burst":{
       "Type":"Steel",
       "Freq":"Scene",
       "DB":"See Effect",
@@ -6269,7 +6269,7 @@
       "Contest Effect":"Double Time",
       "Crits On":20
    },
-   "Metal Claw":{  
+   "Metal Claw":{
       "Type":"Steel",
       "Freq":"At-Will",
       "AC":"3",
@@ -6281,7 +6281,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Metal Sound":{  
+   "Metal Sound":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"4",
@@ -6289,9 +6289,9 @@
       "Range":"Burst 2, Friendly, Sonic",
       "Effect":"All Legal Targets have their Special Defense lowered by -2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling",
+      "Contest Effect":"Unsettling"
    },
-   "Meteor Mash":{  
+   "Meteor Mash":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"4",
@@ -6303,7 +6303,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Mirror Shot":{  
+   "Mirror Shot":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"5",
@@ -6315,16 +6315,16 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Shift Gear":{  
+   "Shift Gear":{
       "Type":"Steel",
       "Freq":"Scene x2",
       "Class":"Status",
       "Range":"Self",
       "Effect":"Raise the user’s Attack by +1 CS and Speed by +2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!",
+      "Contest Effect":"Get Ready!"
    },
-   "Steel Wing":{  
+   "Steel Wing":{
       "Type":"Steel",
       "Freq":"At-Will",
       "AC":"3",
@@ -6336,7 +6336,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Aqua Jet":{  
+   "Aqua Jet":{
       "Type":"Water",
       "Freq":"At-Will",
       "AC":"2",
@@ -6347,16 +6347,16 @@
       "Contest Effect":"Saving Grace",
       "Crits On":20
    },
-   "Aqua Ring":{  
+   "Aqua Ring":{
       "Type":"Water",
       "Freq":"Scene",
       "Class":"Status",
       "Range":"Self, Coat",
       "Effect":"Aqua Ring covers the user in a Coat that heals the user at the beginning of their turn. The user is healed a Tick of Hit Points each turn.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Aqua Tail":{  
+   "Aqua Tail":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"4",
@@ -6367,7 +6367,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Brine":{  
+   "Brine":{
       "Type":"Water",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6379,7 +6379,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Bubble":{  
+   "Bubble":{
       "Type":"Water",
       "Freq":"At-Will",
       "AC":"2",
@@ -6391,7 +6391,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Bubblebeam":{  
+   "Bubblebeam":{
       "Type":"Water",
       "Freq":"At-Will",
       "AC":"2",
@@ -6403,7 +6403,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Clamp":{  
+   "Clamp":{
       "Type":"Water",
       "Freq":"Static",
       "Class":"Static",
@@ -6413,7 +6413,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Crabhammer":{  
+   "Crabhammer":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"4",
@@ -6425,7 +6425,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":18
    },
-   "Dive":{  
+   "Dive":{
       "Type":"Water",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6437,7 +6437,7 @@
       "Contest Effect":" Special Attention",
       "Crits On":20
    },
-   "Hydro Cannon":{  
+   "Hydro Cannon":{
       "Type":"Water",
       "Freq":"Daily x2",
       "AC":"4",
@@ -6448,7 +6448,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Hydro Pump":{  
+   "Hydro Pump":{
       "Type":"Water",
       "Freq":"Scene x2",
       "AC":"4",
@@ -6460,7 +6460,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Muddy Water":{  
+   "Muddy Water":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"5",
@@ -6472,7 +6472,7 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Octazooka":{  
+   "Octazooka":{
       "Type":"Water",
       "Freq":"At-Will",
       "AC":"3",
@@ -6484,7 +6484,7 @@
       "Contest Effect":"Incentives",
       "Crits On":20
    },
-   "Origin Pulse":{  
+   "Origin Pulse":{
       "Type":"Water",
       "Freq":"Scene x2",
       "AC":"5",
@@ -6495,16 +6495,16 @@
       "Contest Effect":"Desperation",
       "Crits On":20
    },
-   "Rain Dance":{  
+   "Rain Dance":{
       "Type":"Water",
       "Freq":"Daily x2",
       "Class":"Status",
       "Range":"Field, Weather",
       "Effect":"The weather becomes Rainy for 5 rounds. While Rainy, Water-Type Attacks gain a +5 bonus to Damage Rolls, and Fire-Type Attacks suffer a -5 Damage penalty.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Razor Shell":{  
+   "Razor Shell":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"3",
@@ -6516,7 +6516,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Scald":{  
+   "Scald":{
       "Type":"Water",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6528,7 +6528,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Soak":{  
+   "Soak":{
       "Type":"Water",
       "Freq":"Daily",
       "AC":"2",
@@ -6536,9 +6536,9 @@
       "Range":"5, 1 Target",
       "Effect":"The target gains the Water type in addition to its other Types for 5 turns.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option",
+      "Contest Effect":"Safe Option"
    },
-   "Surf":{  
+   "Surf":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"2",
@@ -6550,7 +6550,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Water Gun":{  
+   "Water Gun":{
       "Type":"Water",
       "Freq":"At-Will",
       "AC":"2",
@@ -6562,7 +6562,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Water Pledge":{  
+   "Water Pledge":{
       "Type":"Water",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6574,7 +6574,7 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Water Pulse":{  
+   "Water Pulse":{
       "Type":"Water",
       "Freq":"At-Will",
       "AC":"2",
@@ -6586,7 +6586,7 @@
       "Contest Effect":"Exhausting Act",
       "Crits On":20
    },
-   "Water Shuriken":{  
+   "Water Shuriken":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"2",
@@ -6597,16 +6597,16 @@
       "Contest Effect":"Reliable",
       "Crits On":20
    },
-   "Water Sport":{  
+   "Water Sport":{
       "Type":"Water",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Burst 2, Coat",
       "Effect":"All targets in the burst, including the user, gain a Coat which grants them 1 Step of Resistance to Fire Type Moves. After a target has been hit by a damaging Fire Type Move, the coat is removed. *Grants Fountain",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
+      "Contest Effect":"Sabotage"
    },
-   "Water Spout":{  
+   "Water Spout":{
       "Type":"Water",
       "Freq":"Daily",
       "AC":"4",
@@ -6618,7 +6618,7 @@
       "Contest Effect":"Seen Nothing Yet",
       "Crits On":20
    },
-   "Waterfall":{  
+   "Waterfall":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"2",
@@ -6630,7 +6630,7 @@
       "Contest Effect":"Steady Performance",
       "Crits On":20
    },
-   "Whirlpool":{  
+   "Whirlpool":{
       "Type":"Water",
       "Freq":"Scene x2",
       "AC":"4",
@@ -6642,17 +6642,16 @@
       "Contest Effect":"Safe Option",
       "Crits On":20
    },
-   "Withdraw":{  
+   "Withdraw":{
       "Type":"Water",
       "Freq":"At-Will",
       "Class":"Status",
       "Range":"Self",
       "Effect":" The user becomes Withdrawn. While Withdrawn, the user becomes immune to Critical Hits and gain 15 Damage Reduction. However, while Withdrawn, the user cannot Shift, and may only use self-targeting Moves. The user may stop being Withdrawn as a Shift Action.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage",
-      "Crits On":20
+      "Contest Effect":"Sabotage"
    },
-   "Hidden Power Bug":{  
+   "Hidden Power Bug":{
       "Type":"Bug",
       "Freq":"EOT",
       "AC":"2",
@@ -6663,7 +6662,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Dark":{  
+   "Hidden Power Dark":{
       "Type":"Dark",
       "Freq":"EOT",
       "AC":"2",
@@ -6674,7 +6673,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Dragon":{  
+   "Hidden Power Dragon":{
       "Type":"Dragon",
       "Freq":"EOT",
       "AC":"2",
@@ -6685,7 +6684,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Electric":{  
+   "Hidden Power Electric":{
       "Type":"Electric",
       "Freq":"EOT",
       "AC":"2",
@@ -6696,7 +6695,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Fighting":{  
+   "Hidden Power Fighting":{
       "Type":"Fighting",
       "Freq":"EOT",
       "AC":"2",
@@ -6707,7 +6706,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Fire":{  
+   "Hidden Power Fire":{
       "Type":"Fire",
       "Freq":"EOT",
       "AC":"2",
@@ -6718,7 +6717,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Flying":{  
+   "Hidden Power Flying":{
       "Type":"Flying",
       "Freq":"EOT",
       "AC":"2",
@@ -6729,7 +6728,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Ghost":{  
+   "Hidden Power Ghost":{
       "Type":"Ghost",
       "Freq":"EOT",
       "AC":"2",
@@ -6740,7 +6739,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Grass":{  
+   "Hidden Power Grass":{
       "Type":"Grass",
       "Freq":"EOT",
       "AC":"2",
@@ -6751,7 +6750,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Ground":{  
+   "Hidden Power Ground":{
       "Type":"Ground",
       "Freq":"EOT",
       "AC":"2",
@@ -6762,7 +6761,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Ice":{  
+   "Hidden Power Ice":{
       "Type":"Ice",
       "Freq":"EOT",
       "AC":"2",
@@ -6773,7 +6772,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Poison":{  
+   "Hidden Power Poison":{
       "Type":"Poison",
       "Freq":"EOT",
       "AC":"2",
@@ -6784,7 +6783,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Psychic":{  
+   "Hidden Power Psychic":{
       "Type":"Psychic",
       "Freq":"EOT",
       "AC":"2",
@@ -6795,7 +6794,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Rock":{  
+   "Hidden Power Rock":{
       "Type":"Rock",
       "Freq":"EOT",
       "AC":"2",
@@ -6806,7 +6805,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Steel":{  
+   "Hidden Power Steel":{
       "Type":"Steel",
       "Freq":"EOT",
       "AC":"2",
@@ -6817,7 +6816,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Water":{  
+   "Hidden Power Water":{
       "Type":"Water",
       "Freq":"EOT",
       "AC":"2",
@@ -6828,7 +6827,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Hidden Power Fairy":{  
+   "Hidden Power Fairy":{
       "Type":"Fairy",
       "Freq":"EOT",
       "AC":"2",
@@ -6839,7 +6838,7 @@
       "Contest Effect":" Catching Up",
       "Crits On":20
    },
-   "Struggle":{  
+   "Struggle":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"4",
@@ -6848,7 +6847,7 @@
       "Range":"Melee, 1 Target",
       "Crits On":20
    },
-   "Struggle+":{  
+   "Struggle+":{
       "Type":"Normal",
       "Freq":"At-Will",
       "AC":"3",
@@ -6857,7 +6856,7 @@
       "Range":"Melee, 1 Target",
       "Crits On":20
    },
-   "Arcane Fury":{  
+   "Arcane Fury":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"3",
@@ -6867,7 +6866,7 @@
       "Effect":"Arcane Fury’s Targets become Vulnerable on 19+.",
       "Crits On":20
    },
-   "Energy Blast":{  
+   "Energy Blast":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"3",
@@ -6877,7 +6876,7 @@
       "Effect":"You gain +1 Special Attack on 19+.",
       "Crits On":20
    },
-   "Energy Sphere":{  
+   "Energy Sphere":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"3",
@@ -6887,7 +6886,7 @@
       "Effect":"You gain +1 Special Defense Combat Stage on 19+.",
       "Crits On":20
    },
-   "Rending Spell":{  
+   "Rending Spell":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -6897,7 +6896,7 @@
       "Effect":"The target loses a Tick of Hit Points on 16+.",
       "Crits On":20
    },
-   "Resonance Beam":{  
+   "Resonance Beam":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"3",
@@ -6907,7 +6906,7 @@
       "Effect":"All targets have their Special Defense lowered by 1 Combat Stage on 20+. This Effect Range is extended by +1 for each foe targeted by this Move.",
       "Crits On":20
    },
-   "Secret Force":{  
+   "Secret Force":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"4",
@@ -6917,7 +6916,7 @@
       "Effect":"When calculating damage, the target subtracts their Defense from Secret Force’s damage instead of their Special Defense. Secret Force is still otherwise Special.\nLimitation: Melee Weapons Only",
       "Crits On":20
    },
-   "Arcane Storm":{  
+   "Arcane Storm":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6927,7 +6926,7 @@
       "Effect":"All targets of Arcane Storm are Slowed and Vulnerable for 1 Full Round.\nLimitation: Ranged Weapons only",
       "Crits On":20
    },
-   "Bane":{  
+   "Bane":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6937,7 +6936,7 @@
       "Effect":"The target loses a Tick of Hit Points at the start of their next three turns and suffers a -2 penalty to all Save Checks on those turns.",
       "Crits On":20
    },
-   "Cone of Force":{  
+   "Cone of Force":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6947,7 +6946,7 @@
       "Effect":"Cone of Force Pushes all targets 2 meters, and lowers their Evasion by -2 for 1 full round..\nLimitation: Melee Weapons Only",
       "Crits On":20
    },
-   "Energy Vortex":{  
+   "Energy Vortex":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"4",
@@ -6957,7 +6956,7 @@
       "Effect":"The target is put in a Vortex.",
       "Crits On":20
    },
-   "Magic Burst":{  
+   "Magic Burst":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6967,7 +6966,7 @@
       "Effect":"Foes hit by Magic Burst can’t make Attacks of Opportunity for 1 full round.\nLimitation: Melee Weapons Only",
       "Crits On":20
    },
-   "Spirit Lance":{  
+   "Spirit Lance":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -6977,7 +6976,7 @@
       "Effect":"Spirit Lance deals +3 damage to all targets for each target beyond the first that it successfully hits.",
       "Crits On":20
    },
-   "Backswing":{  
+   "Backswing":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -6987,7 +6986,7 @@
       "Effect":"Limitation: Large Melee Weapons Only",
       "Crits On":20
    },
-   "Bash!":{  
+   "Bash!":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -6997,7 +6996,7 @@
       "Effect":"Bash! lowers the target’s Initiative to 0 for 1 full round on 15+.",
       "Crits On":20
    },
-   "Bullseye":{  
+   "Bullseye":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -7007,7 +7006,7 @@
       "Effect":"Bullseye is a Critical Hit on 16+.\nLimitation: Ranged Weapons Only",
       "Crits On":16
    },
-   "Cheap Shot":{  
+   "Cheap Shot":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -7017,7 +7016,7 @@
       "Effect":"Cheap Shot cannot miss.\nLimitation: Small Melee and Short Ranged Weapons Only",
       "Crits On":20
    },
-   "Double Swipe":{  
+   "Double Swipe":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -7026,7 +7025,7 @@
       "Range":"WR, 2 Targets; or WR, 1 Target, Double Strike",
       "Crits On":20
    },
-   "Pierce!":{  
+   "Pierce!":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -7036,7 +7035,7 @@
       "Effect":"Pierce deals an additional +10 damage against targets with Damage Reduction.",
       "Crits On":20
    },
-   "Salvo":{  
+   "Salvo":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -7046,14 +7045,14 @@
       "Effect":"Limitation: Ranged Weapons Only",
       "Crits On":20
    },
-   "Take Aim":{  
+   "Take Aim":{
       "Type":"--",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
-      "Effect":"Raise the user’s Accuracy by +1. If the user performs an Weapon Move on their next turn that deals damage, add its Damage Dice Roll an extra time to the damage.",
+      "Effect":"Raise the user’s Accuracy by +1. If the user performs an Weapon Move on their next turn that deals damage, add its Damage Dice Roll an extra time to the damage."
    },
-   "Wear Down":{  
+   "Wear Down":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -7063,7 +7062,7 @@
       "Effect":"Wear Down lowers the target’s Defense by 1 Combat Stage on Even-Numbered Rolls.",
       "Crits On":20
    },
-   "Wounding Strike":{  
+   "Wounding Strike":{
       "Type":"--",
       "Freq":"EOT",
       "AC":"2",
@@ -7073,7 +7072,7 @@
       "Effect":"The target loses a Tick of Hit Points.",
       "Crits On":20
    },
-   "Bleed!":{  
+   "Bleed!":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -7083,7 +7082,7 @@
       "Effect":"The target loses a Tick of Hit Points at the start of their next three turns.",
       "Crits On":20
    },
-   "Deadly Strike":{  
+   "Deadly Strike":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -7093,7 +7092,7 @@
       "Effect":"If Deadly Strike Hits, it is a Critical Hit.\nLimitation: Not usable by Large Melee Weapons.",
       "Crits On":0
    },
-   "Furious Strikes":{  
+   "Furious Strikes":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -7103,7 +7102,7 @@
       "Effect":"For each hit rolled on your Five Strike roll, the target of the attack has their Evasion reduced by 1 for one full round.\nLimitation: Melee or Short Ranged Weapons Only",
       "Crits On":20
    },
-   "Gouge":{  
+   "Gouge":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -7113,7 +7112,7 @@
       "Effect":"If both hits of Gouge successfully hit the target, the target gains an Injury.\nLimitation: Small Melee and Short Ranged Weapons Only",
       "Crits On":20
    },
-   "Maul":{  
+   "Maul":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -7123,7 +7122,7 @@
       "Effect":"The target is Flinched.\nLimitation: Melee Weapons Only",
       "Crits On":20
    },
-   "Riposte":{  
+   "Riposte":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -7133,7 +7132,7 @@
       "Effect":"Trigger: Your Target misses you with a melee Attack.\nLimitations: Melee or Short-Ranged Weapons Only",
       "Crits On":20
    },
-   "Slice":{  
+   "Slice":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",
@@ -7143,7 +7142,7 @@
       "Effect":"Limitation: Melee Weapons Only",
       "Crits On":20
    },
-   "Sweeping Strike":{  
+   "Sweeping Strike":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"3",
@@ -7153,7 +7152,7 @@
       "Effect":"You may attempt a Trip Maneuver against the target as a free action.\nLimitation: Short-Range Weapons or Weapons with the Reach Quality Only",
       "Crits On":20
    },
-   "Titanic Slam":{  
+   "Titanic Slam":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"3",
@@ -7163,7 +7162,7 @@
       "Effect":"On Even-Numbered Rolls, the target is Slowed for one full round.\nLimitation: Melee Weapons Only",
       "Crits On":20
    },
-   "Triple Threat":{  
+   "Triple Threat":{
       "Type":"--",
       "Freq":"Scene x2",
       "AC":"2",

--- a/data/moves.json
+++ b/data/moves.json
@@ -8,7 +8,8 @@
       "Range":"6, 1 Target",
       "Effect":"Attack Order is a Critical Hit on 18+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":18
    },
    "Bug Bite":{  
       "Type":"Bug",
@@ -19,7 +20,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the target has a stored Digestion/Food Buff or has traded in a Digestion/Food Buff this Scene, the user may gain the effects of the Digestion/Food Buff. This does no count towards the Usual limit on the user's Digestion/Food Buffs.",
       "Contest Type":"Tough",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
+      "Crits On":20
    },
    "Bug Buzz":{  
       "Type":"Bug",
@@ -30,7 +32,8 @@
       "Range":"Cone 2 or Close Blast 2; Sonic, Smite",
       "Effect":"Bug Buzz lowers the Special Defense of all legal targets by -1 CS on 19+.",
       "Contest Type":"Cute",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Defend Order":{  
       "Type":"Bug",
@@ -39,7 +42,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Defense and Special Defense by +1 CS each.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Fell Stinger":{  
       "Type":"Bug",
@@ -50,7 +53,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the user successfully knocks out the target with Fell Stinger, raise the user's Attack by +2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Fury Cutter":{  
       "Type":"Bug",
@@ -61,7 +65,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If Fury Cutter is used successfully and consecutively on the same target, the Damage Base is increased by +4; the first hit has a DB of 4; the second hit a DB of 8, the third hit a DB of 12, and the fourth and all further hits have a DB of 16. If Fury Cutter misses or fails to damage its target, its Damage Base resets.",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Heal Order":{  
       "Type":"Bug",
@@ -70,7 +75,7 @@
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Infestation":{  
       "Type":"Bug",
@@ -81,7 +86,8 @@
       "Range":"3, 1 Target",
       "Effect":"The target is put in a Vortex.",
       "Contest Type":"Smart",
-      "Contest Effect":"Gamble"
+      "Contest Effect":"Gamble",
+      "Crits On":20
    },
    "Leech Life":{  
       "Type":"Bug",
@@ -92,7 +98,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"After the target takes damage, the user gains HP equal to half of the damage they dealt to the target.",
       "Contest Type":"Smart",
-      "Contest Effect":"Good Show!"
+      "Contest Effect":"Good Show!",
+      "Crits On":20
    },
    "Megahorn":{  
       "Type":"Bug",
@@ -103,7 +110,8 @@
       "Range":"Melee, 1 Target, Push",
       "Effect":"The target is Pushed 1 meter.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Pin Missile":{  
       "Type":"Bug",
@@ -113,7 +121,8 @@
       "Class":"Physical",
       "Range":"6, 1 Target, Five Strike",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Powder":{  
       "Type":"Bug",
@@ -122,7 +131,7 @@
       "Range":"6, 1 Target, Interrupt, Powder",
       "Effect":"The target is dusted with a Coat of flammable powder. If the affected target uses a damaging Fire-Type attack, the attack is negated and instead creates a Blast 3 centered on itself as the powder explodes, and the Coat is removed. All legal targets within the Blast take damage equal to what the user of the Fire-Type attack would roll for the damage of their attack. This damage is Typeless or Fire-Type, whichever would be more effective.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Quiver Dance":{  
       "Type":"Bug",
@@ -131,7 +140,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Special Attack, Special Defense, and Speed by +1 CS each.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Rage Powder":{  
       "Type":"Bug",
@@ -140,7 +149,7 @@
       "Range":"Burst 1 or Line 6; Powder",
       "Effect":"All legal targets hit by Rage Powder are Enraged. While enraged, they must shift to target the user when using a Move or Attack if the user is within reach. If the user is Fainted or Switched out, all legal targets hit by Rage Powder are no longer Enraged.",
       "Contest Type":"Smart",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Signal Beam":{  
       "Type":"Bug",
@@ -151,7 +160,8 @@
       "Range":"6, 1 Target",
       "Effect":"Signal Beam Confuses the target on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Silver Wind":{  
       "Type":"Bug",
@@ -162,7 +172,8 @@
       "Range":"6, 1 Target, Spirit Surge",
       "Effect":"Silver Wind raises each of the user's stats by +1 CS on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Spider Web":{  
       "Type":"Bug",
@@ -171,7 +182,7 @@
       "Range":"5, 1 Target",
       "Effect":"Spider Web cannot miss. The target is Stuck and Trapped. If the target is freed of the Stuck condition, it is freed of Trapped as well. *Grants Threaded",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Steamroller":{  
       "Type":"Bug",
@@ -182,7 +193,8 @@
       "Range":"Melee, Pass",
       "Effect":"Steamroller Flinches the target on 15+. If the target is Small, Steamroller deals an additional +5 Damage.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Sticky Web":{  
       "Type":"Bug",
@@ -191,7 +203,7 @@
       "Range":"6, Hazard",
       "Effect":"Set 8 square meters of Sticky Web hazards within your range such that all 8 meters are adjacent with at least one other space of Sticky Web. Sticky Web causes Terrain to become Slow Terrain, and a grounded foe that runs into the hazard has its Speed lowered by -1 CS and becomes Slowed until the end of their next turn. Flying-type Pokémon and Pokémon and Trainers with Levitate are not affected by Sticky Web. Bug-type Pokémon may move over Sticky Web harmlessly, destroying theHazards as they do so. *Grants Threaded",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "String Shot":{  
       "Type":"Bug",
@@ -201,7 +213,7 @@
       "Range":"Cone 2",
       "Effect":"Lower the Speed of all legal targets by -1 CS. If this lowers their Speed CS to -6, or if their Speed CS was already at -6, they are instead Stuck. *Grants Threaded",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Struggle Bug":{  
       "Type":"Bug",
@@ -212,7 +224,8 @@
       "Range":"Cone 2",
       "Effect":"Lower the Special Attack of all legal targets by -1 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
+      "Crits On":20
    },
    "Tail Glow":{  
       "Type":"Bug",
@@ -221,7 +234,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Special Attack by +3 CS. *Grants Glow",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Twineedle":{  
       "Type":"Bug",
@@ -232,7 +245,8 @@
       "Range":"Melee, 1 Target, Double Strike",
       "Effect":"Twineedle Poisons the target on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "U-Turn":{  
       "Type":"Bug",
@@ -243,7 +257,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"The user deals damage and then is immediately recalled to its Poké Ball in the same turn. A New Pokémon may immediately be sent out. Using U-Turn lets a Trapped user be recalled.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
+      "Crits On":20
    },
    "X-Scissor":{  
       "Type":"Bug",
@@ -253,7 +268,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Assurance":{  
       "Type":"Dark",
@@ -264,7 +280,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If Assurance’s target has already been damaged by a Move on the same round Assurance is being used, Assurance has a Damage Base of 12 (3d12+10 / 30) instead. This effect may trigger only once per Scene per Target.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
+      "Crits On":20
    },
    "Beat Up":{  
       "Type":"Dark",
@@ -274,7 +291,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user and up to two allies adjacent to the target may each make a Struggle Attack against the target. These Struggle Attacks hit for Dark-Type Damage instead of their usual Type. Beat Up may trigger Pack Hunt only once, no matter the number of attacks.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Bite":{  
       "Type":"Dark",
@@ -285,7 +303,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Bite Flinches the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Crunch":{  
       "Type":"Dark",
@@ -296,7 +315,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Crunch lowers the target’s Defense by -1 CS on 17+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Dark Pulse":{  
       "Type":"Dark",
@@ -307,7 +327,8 @@
       "Range":"8, 1 Target, Aura",
       "Effect":"Dark Pulse Flinches the target on 17+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Dark Void":{  
       "Type":"Dark",
@@ -317,7 +338,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target falls Asleep. Once per Scene, Dark Void may be used as if its range were “Burst 5, Friendly” instead.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Embargo":{  
       "Type":"Dark",
@@ -327,7 +348,7 @@
       "Range":"6, 1 Target",
       "Effect":"The target cannot use or benefit from held items for the remainder of the encounter. Embargo may only affect one target at a time; if Embargo is used on a new target, the previous target is freed from the effect.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Fake Tears":{  
       "Type":"Dark",
@@ -337,7 +358,7 @@
       "Range":"8, 1 Target, Social",
       "Effect":"Lower the target's Special Defense by -2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Feint Attack":{  
       "Type":"Dark",
@@ -347,7 +368,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Feint Attack Cannot Miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Flatter":{  
       "Type":"Dark",
@@ -357,7 +379,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Raise the target's Special Attack by +1 CS. Flatter Confuses the target.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Fling":{  
       "Type":"Dark",
@@ -368,7 +390,8 @@
       "Range":"6, 1 Target, Fling",
       "Effect":"The user throws a held item, determining the effect of Fling.",
       "Contest Type":"Tough",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Foul Play":{  
       "Type":"Dark",
@@ -379,7 +402,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target reveals its Attack stat. When calculating damage, add the target's Attack stat instead of the user's Attack stat.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Hone Claws":{  
       "Type":"Dark",
@@ -388,7 +412,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Attack by +1 CS and Accuracy by +1.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Knock Off":{  
       "Type":"Dark",
@@ -399,7 +423,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Choose one of the target's Held Items or Accessory Slot Items. It is knocked to the ground.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Memento":{  
       "Type":"Dark",
@@ -408,7 +433,7 @@
       "Range":"8, 1 Target, Trigger, Free Action",
       "Effect":"Memento may be used as a Free Action that does not consume a Command action when the user becomes Fainted. Lower each of the target's stats by -2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
    },
    "Nasty Plot":{  
       "Type":"Dark",
@@ -417,7 +442,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Special Attack by +2 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Night Daze":{  
       "Type":"Dark",
@@ -428,7 +453,8 @@
       "Range":"4, 1 Target",
       "Effect":"Night Daze lowers the target's Accuracy by -1 on 13+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
+      "Crits On":20
    },
    "Night Slash":{  
       "Type":"Dark",
@@ -439,7 +465,8 @@
       "Range":"Melee, Pass",
       "Effect":"Night Slash is a Critical Hit on 18+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":18
    },
    "Parting Shot":{  
       "Type":"Dark",
@@ -449,7 +476,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"If Parting Shot successfully hits, the target's Attack and Special Attack stats are lowered by one CS and the user is immediately recalled in the same turn. A new Pokémon may immediately be sent out. using Parting Shot lets a Trapped user be recalled.",
       "Contest Type":"Smart",
-      "Contest Effect":"Catching Up"
+      "Contest Effect":"Catching Up",
    },
    "Payback":{  
       "Type":"Dark",
@@ -460,7 +487,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the target hit the user with a Damaging Move on the previous turn, Payback has a Damage Base of 10 (3d8+10 / 24) instead.",
       "Contest Type":"Cool",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Punishment":{  
       "Type":"Dark",
@@ -471,7 +499,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Punishment's Damage Base is raised by +1 for each Combat Stage the target has, to a maximum of DB 12.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Pursuit":{  
       "Type":"Dark",
@@ -482,7 +511,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the foe is fleeing or being switched out, Pursuit may be used as an Interrupt, targeting the triggering foe. When used as an Interrupt, Pursuit grants the user a +5 bonus to all Movement Speeds, and has a Damage Base of 8 (2d8+10/19).",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Quash":{  
       "Type":"Dark",
@@ -492,7 +522,7 @@
       "Range":"10, 1 Target, Social",
       "Effect":"Change the target's Initiative to 0 for the remainder of the round.",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
    },
    "Snarl":{  
       "Type":"Dark",
@@ -503,7 +533,8 @@
       "Range":"Cone 2, Sonic",
       "Effect":"Lower the Special Attack of all legal targets by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
+      "Crits On":20
    },
    "Snatch":{  
       "Type":"Dark",
@@ -512,7 +543,7 @@
       "Range":"6, 1 Target, Trigger, Interrupt",
       "Effect":"If the target uses a Self-Targeting Move, you may use Snatch as an Interrupt. You gain the benefits of the Self-Targeting Move instead of the target.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Sucker Punch":{  
       "Type":"Dark",
@@ -523,7 +554,8 @@
       "Range":"Melee, 1 Target, Trigger, Interrupt",
       "Effect":"If an adjacent foe targets the user with a Damaging Attack, Sucker Punch may be used as an Interrupt Move against the triggering foe.",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Switcheroo":{  
       "Type":"Dark",
@@ -533,7 +565,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user and the target exchange held items.",
       "Contest Type":"Cool",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Taunt":{  
       "Type":"Dark",
@@ -543,7 +575,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"The target becomes Enraged.",
       "Contest Type":"Smart",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Thief":{  
       "Type":"Dark",
@@ -554,7 +586,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Thief takes the target's held item and attaches it to Thief's user if the user is not holding anything.",
       "Contest Type":"Tough",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
+      "Crits On":20
    },
    "Topsy-Turvy":{  
       "Type":"Dark",
@@ -564,7 +597,7 @@
       "Range":"6, 1 Target",
       "Effect":"The target’s Combat Stages are inverted; +1 Stage becomes -1 Stage, -3 Stages becomes +3 Stages, etc.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Torment":{  
       "Type":"Dark",
@@ -574,7 +607,7 @@
       "Range":"10, 1 Target, Social",
       "Effect":"The target becomes Suppressed.",
       "Contest Type":"Tough",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Draco Meteor":{  
       "Type":"Dragon",
@@ -585,7 +618,8 @@
       "Range":"8, Ranged Blast 3, Smite",
       "Effect":"Lower the user's Special Attack by -2 CS after damage.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Dragon Claw":{  
       "Type":"Dragon",
@@ -595,7 +629,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Dragon Dance":{  
       "Type":"Dragon",
@@ -604,7 +639,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Speed by +1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Dragon Pulse":{  
       "Type":"Dragon",
@@ -614,7 +649,8 @@
       "Class":"Special",
       "Range":"8, 1 Target, Aura",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Dragon Rage":{  
       "Type":"Dragon",
@@ -625,7 +661,8 @@
       "Range":"4, 1 Target",
       "Effect":"Dragon Rage causes the target to lose 15 HP. Dragon Rage is Special and interacts with other moves and effects as such (Special Evasion may be applied to avoid it, Mirror Coat can reflect it, etc.).",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Dragon Rush":{  
       "Type":"Dragon",
@@ -636,7 +673,8 @@
       "Range":"Melee, 1 Target, Dash, Push, Smite",
       "Effect":"The target is Pushed 3 Meters. Dragon Rush Flinches the target on 17+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Dragon Tail":{  
       "Type":"Dragon",
@@ -647,7 +685,8 @@
       "Range":"Melee, 1 Target, Push",
       "Effect":"The target is Pushed 6 meters minus their Weight Class. The target is also Tripped on 15+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Dragon Breath":{  
       "Type":"Dragon",
@@ -658,7 +697,8 @@
       "Range":"6, 1 Target",
       "Effect":"Dragon Breath Paralyzes the target on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Dual Chop":{  
       "Type":"Dragon",
@@ -668,7 +708,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Double Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Outrage":{  
       "Type":"Dragon",
@@ -679,7 +720,8 @@
       "Range":"Melee, All Adjacent Foes, Smite",
       "Effect":"Outrage makes the user becomes Enraged and Confused after damage is dealt.",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Roar of Time":{  
       "Type":"Dragon",
@@ -690,7 +732,8 @@
       "Range":"Burst 8, Smite, Exhaust",
       "Effect":"Roar of Time Slows all legal targets, even if the attack misses.",
       "Contest Type":"Cool",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Spacial Rend":{  
       "Type":"Dragon",
@@ -701,7 +744,8 @@
       "Range":"10, 1 Target",
       "Effect":"Spacial Rend is a Critical Hit on Even-Numbered Rolls.",
       "Contest Type":"Tough",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":"Even"
    },
    "Twister":{  
       "Type":"Dragon",
@@ -712,7 +756,8 @@
       "Range":"6, Ranged Blast 3",
       "Effect":"Twister Flinches the target on 18+. Small or Medium targets in the central square of the blast are not hit. Any Pokémon Airborne as a result of Bounce, Fly, or Sky Drop above the Blast are hit, ignoring range, and Twister has a Damage Base of 8 against those targets instead.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Bolt Strike":{  
       "Type":"Electric",
@@ -723,7 +768,8 @@
       "Range":"10, 1 Target, Smite",
       "Effect":"Bolt Strike Paralyzes the target on 17+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Charge":{  
       "Type":"Electric",
@@ -732,7 +778,7 @@
       "Range":"Self",
       "Effect":"If the user performs an Electric Attack on its next turn, add its Damage Dice Roll an extra time to the damage. Raise the user's Special Defense by +1 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Charge Beam":{  
       "Type":"Electric",
@@ -743,7 +789,8 @@
       "Range":"6, 1 Target",
       "Effect":"If Charge Beam successfully hits a target, roll 1d20. On a roll of 7+, the user's Special Attack is raised by +1 Combat Stage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Discharge":{  
       "Type":"Electric",
@@ -754,7 +801,8 @@
       "Range":"All Cardinally Adjacent Targets",
       "Effect":"Discharge Paralyzes all legal targets on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Eerie Impulse":{  
       "Type":"Electric",
@@ -764,7 +812,7 @@
       "Range":"6, 1 Target",
       "Effect":"Lower the target's Special Attack by -2 CS. *Grants Glow.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Electric Terrain":{  
       "Type":"Electric",
@@ -773,7 +821,7 @@
       "Range":"Field",
       "Effect":"The field becomes Electrified for 5 rounds. While the field is Electrified, Pokémon and Trainers touching the ground are immune to Sleep, and Electric-Type attacks used by Pokémon and Trainers touching the ground gain a +10 Bonus to Damage Rolls.",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Electrify":{  
       "Type":"Electric",
@@ -782,7 +830,7 @@
       "Range":"6, 1 Target.",
       "Effect":"Until the end of the user's next turn, the target's damaging Water-Type attacks and Melee attacks of any Type deal Electric-Type Damage instead of their usual Type.",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Electro Ball":{  
       "Type":"Electric",
@@ -793,7 +841,8 @@
       "Range":"10, 1 Target",
       "Effect":"When determining the damage dealt by Electro Ball, the user adds its Speed Stat (including CS) in addition to their Special Attack Stat. The target in turn subtracts both its Speed and Special Defense Stats from the damage dealt before applying Type Effectiveness.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Electroweb":{  
       "Type":"Electric",
@@ -804,7 +853,8 @@
       "Range":"4, Ranged Blast 2",
       "Effect":"Lower the Speed of all legal targets by -1 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
+      "Crits On":20
    },
    "Fusion Bolt":{  
       "Type":"Electric",
@@ -815,7 +865,8 @@
       "Range":"8, 1 Target, Smite",
       "Effect":"Fusion Bolt has its Damage Base increased by +3 if Fusion Flare was used this round or last round by any participant of the encounter.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Ion Deluge":{  
       "Type":"Electric",
@@ -824,7 +875,7 @@
       "Range":"5, Ranged Blast 3, Interrupt",
       "Effect":"An ion cloud is dispersed in the targeted area. All Normal-Type Moves targeting into or originating from the area become Electric-Type Moves.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Magnet Rise":{  
       "Type":"Electric",
@@ -833,7 +884,7 @@
       "Range":"Self, Swift Action",
       "Effect":"The user gains the Levitate Ability for 5 turns. Magnet Rise may be activated as a Swift Action if the user is otherwise given an action that consumes a Command.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Magnetic Flux":{  
       "Type":"Electric",
@@ -842,7 +893,7 @@
       "Range":"Burst 4",
       "Effect":"Raise the Defense and Special Defense of all legal targets with the Minus or Plus Abilities by +1 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
    },
    "Nuzzle":{  
       "Type":"Electric",
@@ -853,7 +904,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Nuzzle Paralyzes the target.",
       "Contest Type":"Cute",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
+      "Crits On":20
    },
    "Parabolic Charge":{  
       "Type":"Electric",
@@ -864,7 +916,8 @@
       "Range":"Cone 2",
       "Effect":"The user gains HP equal to half of the total damage the user dealt to all legal targets.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Shock Wave":{  
       "Type":"Electric",
@@ -874,7 +927,8 @@
       "Range":"6, 1 Target",
       "Effect":"Shock Wave cannot miss. *Grants Zapper",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Spark":{  
       "Type":"Electric",
@@ -885,7 +939,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Spark Paralyzes the target on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Thunder":{  
       "Type":"Electric",
@@ -896,7 +951,8 @@
       "Range":"12, 1 Target, Smite",
       "Effect":"Thunder Paralyzes the target on 15+. If the target is in Sunny Weather, Thunder's Accuracy Check is 11. If the target is in Rainy Weather, Thunder cannot miss. If the target is airborne as a result of Bounce, Fly, or Sky Drop, Thunder cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Thunder Fang":{  
       "Type":"Electric",
@@ -907,7 +963,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Thunder Fang Paralyzes or Flinches on 18-19; flip a coin to determine whether the foe becomes Paralyzed or Flinched. On 20, the foe is both Paralyzed and Flinched.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Thunderbolt":{  
       "Type":"Electric",
@@ -918,7 +975,8 @@
       "Range":"4, 1 Target",
       "Effect":"Thunderbolt Paralyzes the target on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Thunder Punch":{  
       "Type":"Electric",
@@ -929,7 +987,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Thunder Punch Paralyzes the target on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Thunder Shock":{  
       "Type":"Electric",
@@ -940,7 +999,8 @@
       "Range":"4, 1 Target",
       "Effect":"Thunder Shock Paralyzes the target on 17+. *Grants Zapper",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Thunder Wave":{  
       "Type":"Electric",
@@ -949,7 +1009,7 @@
       "Range":"6, 1 Target",
       "Effect":"Thunder Wave cannot miss. Thunder Wave Paralyzes the target. Pokémon immune to Electric Attacks are immune to Thunder Wave's effects.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Volt Switch":{  
       "Type":"Electric",
@@ -960,7 +1020,8 @@
       "Range":"5, 1 Target",
       "Effect":"If Volt Switch successfully hits its target, the user deals damage and then immediately is returned to its Poke Ball in the same turn. A New Pokémon may immediately be sent out. Using Volt Switch lets a Trapped user be recalled",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
+      "Crits On":20
    },
    "Volt Tackle":{  
       "Type":"Electric",
@@ -971,7 +1032,8 @@
       "Range":"Melee, 1 Target, Dash, Recoil 1/3",
       "Effect":"Volt Tackle Paralyzes the target on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Wild Charge":{  
       "Type":"Electric",
@@ -981,7 +1043,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash, Recoil 1/4",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Zap Cannon":{  
       "Type":"Electric",
@@ -992,7 +1055,8 @@
       "Range":"12, 1 Target",
       "Effect":"Zap Cannon Paralyzes the target. Zap Cannon ignores the target's Evasion if their are no other combatants or Rough or Blocking Terrain within 2 meters of the target.",
       "Contest Type":"Cool",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Aromatic Mist":{  
       "Type":"Fairy",
@@ -1001,7 +1065,7 @@
       "Range":"Burst 1",
       "Effect":"Raise the Special Defense of all allied legal targets by +1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Baby-Doll Eyes":{  
       "Type":"Fairy",
@@ -1011,7 +1075,7 @@
       "Range":" 4, 1 Target, Priority, Social",
       "Effect":"Lower the target's Attack by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Charm":{  
       "Type":"Fairy",
@@ -1021,7 +1085,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Lower the target’s Attack by -2 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Crafty Shield":{  
       "Type":"Fairy",
@@ -1030,7 +1094,7 @@
       "Range":"Burst 2, Trigger, Interrupt, Shield",
       "Effect":"If the user or an Ally within 2 meters of Crafty Shield's user is hit by a Status Move, you may use Crafty Shield as an Interrupt. All targets in Crafty Shield's area-of-effect including the user, are instead not hit by the triggering Move and do not suffer any of its effects.",
       "Contest Type":"Smart",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Dazzling Gleam":{  
       "Type":"Fairy",
@@ -1040,7 +1104,8 @@
       "Class":"Special",
       "Range":"Cone 2",
       "Contest Type":"Cute",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Disarming Voice":{  
       "Type":"Fairy",
@@ -1050,7 +1115,8 @@
       "Range":"Burst 1",
       "Effect":"Disarming Voice cannot miss.",
       "Contest Type":"Cute",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Draining Kiss":{  
       "Type":"Fairy",
@@ -1061,7 +1127,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user gains HP equal to half of the damage the user dealt to the target.",
       "Contest Type":"Cute",
-      "Contest Effect":"Good Show!"
+      "Contest Effect":"Good Show!",
+      "Crits On":20
    },
    "Fairy Lock":{  
       "Type":"Fairy",
@@ -1070,7 +1137,7 @@
       "Range":"Burst 3, Friendly",
       "Effect":"All legal targets become Trapped and Slowed while the user remains in the encounter. If the user is switched or knocked out, this effect ends.",
       "Contest Type":"Cute",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Fairy Wind":{  
       "Type":"Fairy",
@@ -1080,7 +1147,8 @@
       "Class":"Special",
       "Range":"6, 1 Target",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Flower Shield":{  
       "Type":"Fairy",
@@ -1089,7 +1157,7 @@
       "Range":"Burst 2",
       "Effect":"Raise the Defense of all Grass-Type legal targets by +2 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Geomancy":{  
       "Type":"Fairy",
@@ -1098,7 +1166,7 @@
       "Range":"Self, Set Up",
       "Effect":"Set-Up Effect: The user may not shift this round. The user may create as many squares of Rough Terrain as it wants within a Burst 3 as plants burst through the ground, regardless of the surface material. Resolution Effect: Geomancy raises the user's Special Attack, Special Defense, and Speed by +2 CS.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Catching Up"
+      "Contest Effect":"Catching Up",
    },
    "Light of Ruin":{  
       "Type":"Fairy",
@@ -1108,7 +1176,8 @@
       "Class":"Special",
       "Range":"8, Ranged Blast 3, Smite, Recoil 1/2",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Sweet Kiss":{  
       "Type":"Fairy",
@@ -1118,7 +1187,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"The target is Confused. On miss, the target suffers a -2 penalty to Accuracy Rolls for one full round.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Misty Terrain":{  
       "Type":"Fairy",
@@ -1127,7 +1196,7 @@
       "Range":"Field",
       "Effect":"The area becomes Misty for 5 turns, While Misty, all Pokémon and Traners standing on the ground ignore the first turn of all Status Afflictions, and Dragon-type attacks targeting or origination from a grounded Pokémon or Trainer take a -10 Penalty to Damage Rolls.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Moonblast":{  
       "Type":"Fairy",
@@ -1138,7 +1207,8 @@
       "Range":"6, 1 Target",
       "Effect":"Moonblast lowers the target’s Special Attack by -1 CS on 15+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Apeal"
+      "Contest Effect":"Reflective Apeal",
+      "Crits On":20
    },
    "Moonlight":{  
       "Type":"Fairy",
@@ -1147,7 +1217,7 @@
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP. If it is Sunny, the user gains 2/3 of its full HP. If it is Rainy, Sand Storming, or Hailing, the user gains 1/4 of its full HP.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Play Rough":{  
       "Type":"Fairy",
@@ -1158,7 +1228,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Play Rough lowers the target’s Attack by -1 CS on 17+.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
+      "Crits On":20
    },
    "Arm Thrust":{  
       "Type":"Fighting",
@@ -1168,7 +1239,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Five Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Aura Sphere":{  
       "Type":"Fighting",
@@ -1178,7 +1250,8 @@
       "Range":"8, 1 Target, Aura",
       "Effect":"Aura Sphere cannot miss.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Brick Break":{  
       "Type":"Fighting",
@@ -1189,7 +1262,8 @@
       "Range":"Melee, 1 Target",
       "Effect":" Light Screen and Reflect may not be activated in response to Brick Break.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Bulk Up":{  
       "Type":"Fighting",
@@ -1198,7 +1272,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Defense by +1 CS each.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Circle Throw":{  
       "Type":"Fighting",
@@ -1209,7 +1283,8 @@
       "Range":"Melee, 1 Target, Push",
       "Effect":"The target is Pushed 6 meters minus their Weight Class. The target is also Tripped on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Close Combat":{  
       "Type":"Fighting",
@@ -1220,7 +1295,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Lower the user’s Defense and Special Defense by -1 CS each after damage.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Counter":{  
       "Type":"Fighting",
@@ -1230,7 +1306,8 @@
       "Range":"Melee, 1 Target, Reaction, Trigger",
       "Effect":"Counter may be used as a Reaction when the user is hit by a damaging Physical Attack. Resolve the Triggering Attack, with Counter's user resisting the attack one step further. After the attack is resolved, if Counter's user was not Fainted, the triggering foe then loses Hit Points equal to twice the amount of Hit Points lost by the user from the triggering attack. Note that Counter is Physical, and while it cannot miss, it cannot hit targets immune to Fighting-Type Moves.",
       "Contest Type":"Tough",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Cross Chop":{  
       "Type":"Fighting",
@@ -1241,7 +1318,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Cross Chop is a Critical Hit on 16+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":16
    },
    "Detect":{  
       "Type":"Fighting",
@@ -1250,7 +1328,7 @@
       "Range":"Self, Trigger, Interrupt, Shield",
       "Effect":"If the user is hit by a Move, the user may use Detect. The user is instead not hit by the Move. You do not take any damage nor are you affected by anty of the Move's effects",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Double Kick":{  
       "Type":"Fighting",
@@ -1260,7 +1338,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Double Strike",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Drain Punch":{  
       "Type":"Fighting",
@@ -1271,7 +1350,8 @@
       "Range":"Melee, 1 Target, Aura",
       "Effect":"After the target takes damage, the user gains HP equal to half of the damage it dealt to the target.",
       "Contest Type":"Beauty",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Dynamic Punch":{  
       "Type":"Fighting",
@@ -1282,7 +1362,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Dynamic Punch Confuses the target. Dynamic Punch ignores the target's Evasion if they are Flanked.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Final Gambit":{  
       "Type":"Fighting",
@@ -1292,7 +1373,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Final Gambit lowers the user to 0 Hit Points and causes them to Faint. Final Gambit then deals 1 point of damage to the target for every Hit Point lost by the user. Final Gambit does not cause items to activate.",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Flying Press":{  
       "Type":"Fighting",
@@ -1303,7 +1385,8 @@
       "Range":"Melee, Dash, 1 Target",
       "Effect":"Flying Press may deal Flying Type damage if the user wishes. NOTE: If Flying Press is Move Sync'd, it only changes the Fighting Type portion of the Move. You can still only choose between that Type and Flying Type; you cannot shift Flying Press to change the Flying part to another Type.",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Focus Blast":{  
       "Type":"Fighting",
@@ -1314,7 +1397,8 @@
       "Range":"6, 1 Target, Smite, Aura",
       "Effect":"Focus Blast lowers the target's Special Defense by -1 CS on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Focus Punch":{  
       "Type":"Fighting",
@@ -1325,7 +1409,8 @@
       "Range":"Melee, 1 Target, Priority (Limited), Aura",
       "Effect":"Use of Focus Punch must be declared as a Priority (Limited) action at the beginning of the round. Nothing happens at this time. At the end of the round, if the target hasn't been hit by an attack dealing damage equal to at least 25% of the user's Maximum Hit Points, the user may Shift and use Focus Punch. Focus Punch's Frequency is not expended if it is negated by an attack.",
       "Contest Type":"Tough",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Force Palm":{  
       "Type":"Fighting",
@@ -1336,7 +1421,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Force Palm Paralyzes the target on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Hammer Arm":{  
       "Type":"Fighting",
@@ -1347,7 +1433,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user lowers their Speed by -1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "High Jump Kick":{  
       "Type":"Fighting",
@@ -1358,7 +1445,8 @@
       "Range":"Melee, Dash, 1 Target",
       "Effect":"If High Jump Kick misses, the user loses Hit Points equal to 1/4th of their Max Hit Points. A failure to hit due to a Move with the Shield keyword does not count as a miss. This cannot be used if Gravity is in effect.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Jump Kick":{  
       "Type":"Fighting",
@@ -1369,7 +1457,8 @@
       "Range":"Melee, Dash, 1 Target",
       "Effect":"If Jump Kick misses, the user loses Hit Points equal to 1/4th of their Max Hit Points. A failure to hit due to a Move with the Shield keyword does not count as a miss. This cannot be used if Gravity is in effect.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Karate Chop":{  
       "Type":"Fighting",
@@ -1380,7 +1469,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Karate Chop is a Critical Hit on 17+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":17
    },
    "Low Kick":{  
       "Type":"Fighting",
@@ -1391,7 +1481,8 @@
       "Range":"Melee, 1 Target, Weight Class",
       "Effect":"Low Kick's Damage Base is equal to twice the target's Weight Class.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Low Sweep":{  
       "Type":"Fighting",
@@ -1402,7 +1493,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Lower the target’s Speed by -1 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Mach Punch":{  
       "Type":"Fighting",
@@ -1412,7 +1504,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Priority",
       "Contest Type":"Cool",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Mat Block":{  
       "Type":"Fighting",
@@ -1421,7 +1514,7 @@
       "Range":"Self, Trigger, Interrupt, Shield",
       "Effect":"If the user or an adjacent ally is hit by a damagin attack, the user may use Mat Block. The attack instead does not hit any targets, and it deals no damage and has no effects. You may only use Mat Block during the first round of an encounter",
       "Contest Type":"Tough",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Power-Up Punch":{  
       "Type":"Fighting",
@@ -1432,7 +1525,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If Power-Up Punch successfully hits a target, the user's Attack is raised by +1 Combat Stage",
       "Contest Type":"Tough",
-      "Contest Effect":"Catching Up"
+      "Contest Effect":"Catching Up",
+      "Crits On":20
    },
    "Quick Guard":{  
       "Type":"Fighting",
@@ -1441,7 +1535,7 @@
       "Range":"Melee, Interrupt, Shield, Trigger",
       "Effect":"If the user or an adjacent ally is targeted by a Priority or Interrupt Attack, Quick Guard may be declared as an Interrupt, causing the triggering attack to have no effect.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Revenge":{  
       "Type":"Fighting",
@@ -1452,7 +1546,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"When declaring Revenge, the user does nothing and may not Shift. At the end of the round, the user may Shift and use Revenge. If the target damaged the user this round, Revenge has a Damage Base of 12 (4d10+15 / 40).",
       "Contest Type":"Tough",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Reversal":{  
       "Type":"Fighting",
@@ -1463,7 +1558,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"For each Injury the user has, Reversal's Damage Base is increased by +1.",
       "Contest Type":"Cool",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Rock Smash":{  
       "Type":"Fighting",
@@ -1474,7 +1570,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Rock Smash lowers the target’s Defense 1 Combat Stage on 17+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Rolling Kick":{  
       "Type":"Fighting",
@@ -1485,7 +1582,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Rolling Kick Flinches the target on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Sacred Sword":{  
       "Type":"Fighting",
@@ -1495,7 +1593,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Sacred Sword cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Secret Sword":{  
       "Type":"Fighting",
@@ -1506,7 +1605,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"When calculating damage, the target subtracts their Defense from Secret Sword's damage instead of their Special Defense. Psyshock is still otherwise Special (Special Evasion is used to avoid it, Mirror Coat can reflect it, etc.)",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Seismic Toss":{  
       "Type":"Fighting",
@@ -1516,7 +1616,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target loses HP equal to the level of Seismic Toss's user. Do not apply weakness or resistance. Do not apply stats.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Sky Uppercut":{  
       "Type":"Fighting",
@@ -1527,7 +1628,8 @@
       "Range":"Melee, 1 Target, Interrupt",
       "Effect":"Sky Uppercut may be used as an Interrupt when against a target initiating Bounce, Fly, or Sky Drop. If Sky Uppercut successfully hits its target, the Triggering Move fails (though the target may take their next turn normally.)",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Storm Throw":{  
       "Type":"Fighting",
@@ -1538,7 +1640,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If Storm Throw hits, it is a Critical Hit.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":0
    },
    "Submission":{  
       "Type":"Fighting",
@@ -1549,7 +1652,8 @@
       "Range":"Melee, 1 Target, Recoil 1/3",
       "Effect":"On an accuracy roll of 15+, the target is Tripped.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Superpower":{  
       "Type":"Fighting",
@@ -1560,7 +1664,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Superpower lowers the user's Attack and Defense by 1 Combat Stage each.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Triple Kick":{  
       "Type":"Fighting",
@@ -1571,7 +1676,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Make three attacks with Triple Kick. If you hit once, Triple Kick has a DB of 1. If you hit two times, Triple Kick has a DB of 3. If you hit three times, Triple Kick has a DB of 6.",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Vacuum Wave":{  
       "Type":"Fighting",
@@ -1581,7 +1687,8 @@
       "Class":"Special",
       "Range":"4, 1 Target, Priority, Aura",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Vital Throw":{  
       "Type":"Fighting",
@@ -1591,7 +1698,8 @@
       "Range":"Melee, 1 Target, Push, Reaction",
       "Effect":"If the user is targeted by a Melee attack and has not yet taken a turn this round, the user may declare Vital Throw. After the triggering attack is resolved, the user may use Vital Throw against the triggering foe as a Reaction. Vital Throw cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Wake-Up Slap":{  
       "Type":"Fighting",
@@ -1602,7 +1710,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the target is Asleep, Wake-Up Slap has a Damage Base of 10 (3d8+10 / 24) instead, and cures the target of Sleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
+      "Crits On":20
    },
    "Blast Burn":{  
       "Type":"Fire",
@@ -1612,7 +1721,8 @@
       "Class":"Special",
       "Range":"Close Blast 3, Smite, Exhaust",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Blaze Kick":{  
       "Type":"Fire",
@@ -1623,7 +1733,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Blaze Kick Burns the target on 19+ and is a Critical Hit on 18+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":18
    },
    "Blue Flare":{  
       "Type":"Fire",
@@ -1634,7 +1745,8 @@
       "Range":"10, 1 Target, Smite",
       "Effect":"Blue Flare Burns the target on 17+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Ember":{  
       "Type":"Fire",
@@ -1645,7 +1757,8 @@
       "Range":"4, 1 Target",
       "Effect":"Ember Burns the target on 18+. *Grants: Firestarter",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Eruption":{  
       "Type":"Fire",
@@ -1656,7 +1769,8 @@
       "Range":"Burst 1*",
       "Effect":"For each 10% of HP the user is missing, Eruption's Damage Base is reduced by 1. Eruption creates a 1 meter burst, but also affects an area 10 meters tall straight up.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Fiery Dance":{  
       "Type":"Fire",
@@ -1667,7 +1781,8 @@
       "Range":"4, 1 Target",
       "Effect":"If Fiery Dance successfully hits a foe, it raises the user's Special Attack by 1 Combat Stage on Even-Numbered Rolls.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Fire Blast":{  
       "Type":"Fire",
@@ -1678,7 +1793,8 @@
       "Range":"6, 1 Target, Smite",
       "Effect":"Fire Blast burns the target on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Fire Fang":{  
       "Type":"Fire",
@@ -1689,7 +1805,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Fire Fang Burns or Flinches on 18-19 during Accuracy Check; flip a coin to determine whether the foe becomes Burned or Flinched. On 20 during Accuracy Check, the foe is both Burned and Flinched.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Fire Pledge":{  
       "Type":"Fire",
@@ -1700,7 +1817,8 @@
       "Range":"6, 1 Target, Pledge",
       "Effect":"If an ally uses Grass Pledge or Water Pledge, you may use Fire Pledge as Priority (Advanced) immediately after their turn to target the same foe. If used in conjunction with Grass Pledge, Fire Hazards are created in a Brust 1 around the target. If used in conjucntion with Water Pledge, a Rainbow is created that lasts for 5 rouns. Counsult the Pledge keyword for additional details.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Fire Punch":{  
       "Type":"Fire",
@@ -1711,7 +1829,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Fire Punch Burns the target on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Fire Spin":{  
       "Type":"Fire",
@@ -1722,7 +1841,8 @@
       "Range":"3, 1 Target",
       "Effect":"The target is put in a Vortex. *Grants: Firestarter",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Flame Burst":{  
       "Type":"Fire",
@@ -1733,7 +1853,8 @@
       "Range":"6, 1 Target",
       "Effect":"Any Trainers or Pokémon cardinally adjacent to the target lose 5 Hit Points",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Flame Charge":{  
       "Type":"Fire",
@@ -1744,7 +1865,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Raise the user’s Speed 1 Combat Stage.",
       "Contest Type":"Tough",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
+      "Crits On":20
    },
    "Flame Wheel":{  
       "Type":"Fire",
@@ -1755,7 +1877,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Flame Wheel Burns the target on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Flamethrower":{  
       "Type":"Fire",
@@ -1766,7 +1889,8 @@
       "Range":"4, 1 Target",
       "Effect":"Flamethrower Burns the target on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Flare Blitz":{  
       "Type":"Fire",
@@ -1777,7 +1901,8 @@
       "Range":"Melee, 1 Target, Dash, Recoil 1/3",
       "Effect":"Flare Blitz Burns the target on 19+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Fusion Flare":{  
       "Type":"Fire",
@@ -1788,7 +1913,8 @@
       "Range":"8, 1 Target, Smite",
       "Effect":"If Fusion Bolt was used this round or last round by any participant of the encounter, Fusion Flare has its Damage Base increased by +3.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Heat Crash":{  
       "Type":"Fire",
@@ -1799,7 +1925,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"For each weight class the user is above the target, increase Heavy Crash's damage base by +2.",
       "Contest Type":"Tough",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Heat Wave":{  
       "Type":"Fire",
@@ -1810,7 +1937,8 @@
       "Range":"Close Blast 3, Smite",
       "Effect":"Heat Wave Burns all Legal Targets on 18+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Incinerate":{  
       "Type":"Fire",
@@ -1821,7 +1949,8 @@
       "Range":"Line 3",
       "Effect":"If a target is holding a Held Item or Main or Off-Hand item, they must either drop it immediately or lose a Tick of Hit Points. This may only cause a target to lose at most one Tick of Hit Points, no matter how many items they were holding",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Inferno":{  
       "Type":"Fire",
@@ -1832,7 +1961,8 @@
       "Range":"6, 1 Target",
       "Effect":"Inferno Burns the target. Inferno ignores the target's Evasion if there are no other combatants or Rough or Blocking Terrain within 2 meters of the target.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Lava Plume":{  
       "Type":"Fire",
@@ -1843,7 +1973,8 @@
       "Range":"Burst 1",
       "Effect":"Lava Plume burns all targets on 16+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Magma Storm":{  
       "Type":"Fire",
@@ -1854,7 +1985,8 @@
       "Range":"6, 1 Target",
       "Effect":"The target is put in a Vortex; this effect occurs even if Magma Storm misses its target.",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Mystical Fire":{  
       "Type":"Fire",
@@ -1865,7 +1997,8 @@
       "Range":"6, 1 Target",
       "Effect":"Mystical Fire lowers the target’s Special Attack by 1 Combat Stage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Special Attention"
+      "Contest Effect":"Special Attention",
+      "Crits On":20
    },
    "Overheat":{  
       "Type":"Fire",
@@ -1876,7 +2009,8 @@
       "Range":"8, Ranged Blast 3, Smite",
       "Effect":"Lower the user's Special Attack 2 Combat Stages after damage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Sacred Fire":{  
       "Type":"Fire",
@@ -1887,7 +2021,8 @@
       "Range":"6, 1 Target",
       "Effect":"Sacred Fire Burns the target on Even-Numbered Rolls.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Searing Shot":{  
       "Type":"Fire",
@@ -1898,7 +2033,8 @@
       "Range":"Burst 1",
       "Effect":"Searing Shot Burns all targets on 15+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Sunny Day":{  
       "Type":"Fire",
@@ -1907,7 +2043,7 @@
       "Range":"Field, Weather",
       "Effect":"The weather becomes Sunny for 5 rounds. While Sunny, Fire-Type Attacks gain a +5 bonus to Damage Rolls, and Water-Type Attacks suffer a -5 Damage penalty.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "V-Create":{  
       "Type":"Fire",
@@ -1918,7 +2054,8 @@
       "Range":"Melee, 1 Target, Smite",
       "Effect":"Lowers the user's Defense, Special Defense, and Speed by -1 CS each.",
       "Contest Type":" Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Will-O-Wisp":{  
       "Type":"Fire",
@@ -1928,7 +2065,7 @@
       "Range":"6, 1 Target",
       "Effect":"The target is Burned.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
    },
    "Acrobatics":{  
       "Type":"Flying",
@@ -1939,7 +2076,8 @@
       "Range":"Melee, Dash, 1 Target",
       "Effect":"If the user is not holding an item, Acrobatics instead has a Damage Base of 11 (3d10+10/27)",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Aerial Ace":{  
       "Type":"Flying",
@@ -1949,7 +2087,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Aerial Ace cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Aeroblast":{  
       "Type":"Flying",
@@ -1960,7 +2099,8 @@
       "Range":"Line 6",
       "Effect":"Aeroblast is a Critical Hit on an Even-Numbered Roll.",
       "Contest Type":"Cool",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":"Even"
    },
    "Air Cutter":{  
       "Type":"Flying",
@@ -1971,7 +2111,8 @@
       "Range":"Cone 2",
       "Effect":"Air Cutter is a Critical Hit on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":18
    },
    "Air Slash":{  
       "Type":"Flying",
@@ -1982,7 +2123,8 @@
       "Range":"6, 1 Target",
       "Effect":"Air Slash Flinches the target on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Bounce":{  
       "Type":"Flying",
@@ -1993,7 +2135,8 @@
       "Range":"Melee, 1 Target, Dash, Full Action",
       "Effect":"The user first Shifts, gaining a +1 Bonus to Movement Speed and to their Jump Capabilities. After the user Shifts, they may attack with Bounce. The target becomes Vulnerable, and is Paralyzed on 16+. Grants High Jump +1",
       "Contest Type":"Cute",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Brave Bird":{  
       "Type":"Flying",
@@ -2004,7 +2147,8 @@
       "Range":"Melee, 1 Target, Dash, Push, Recoil 1/3",
       "Effect":"The target is pushed back 2 meters.",
       "Contest Type":"Cute",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Chatter":{  
       "Type":"Flying",
@@ -2015,7 +2159,8 @@
       "Range":"4, 1 Target, Sonic",
       "Effect":"Chatter confuses all targets on 16+.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Defog":{  
       "Type":"Flying",
@@ -2024,7 +2169,7 @@
       "Range":"Field, Weather",
       "Effect":"The Weather becomes Clear, and all Blessings, Coats, and Hazards are destroyed. Clear Weather is the default weather, conferring no bonuses or penalties of any sort.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Dragon Ascent":{  
       "Type":"Flying",
@@ -2035,7 +2180,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"The user’s Defense and Special Defense are each lowered by -1 Combat Stage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Drill Peck":{  
       "Type":"Flying",
@@ -2045,7 +2191,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Feather Dance":{  
       "Type":"Flying",
@@ -2055,7 +2202,7 @@
       "Range":"Burst 1, Friendly",
       "Effect":"All legal targets have their Attack lowered 2 Combat Stages.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Fly":{  
       "Type":"Flying",
@@ -2066,7 +2213,8 @@
       "Range":"Melee, Dash, Set-Up",
       "Effect":"Set-Up Effect: The user is moved up 25 meters into the air. Resolution Effect: The user may shift twice while in the air, using their overland or sky speed, and then comes down next to a legal target, and attacks with Fly. *Grants: Sky +3",
       "Contest Type":"Smart",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Gust":{  
       "Type":"Flying",
@@ -2077,7 +2225,8 @@
       "Range":"4, 1 Target",
       "Effect":"If the target is airborne as a result of Bounce, Fly, or Sky Drop, Gust can hit them, ignoring Range and has a Damage Base of 8 instead. *Grants: Guster",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Hurricane":{  
       "Type":"Flying",
@@ -2088,7 +2237,8 @@
       "Range":"Burst 1, Smite",
       "Effect":"Hurricane Confuses its target on 15+. If the target is in Sunny Weather, Hurricane's Accuracy Check is 11. If the target is in Rainy Weather, Hurricane cannot miss. If the target is airborne as a result of Bounce, Fly, or Sky Drop, Hurricane cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Mirror Move":{  
       "Type":"Flying",
@@ -2098,7 +2248,7 @@
       "Range":"6, 1 Target, Illusion",
       "Effect":"Use the Move the target has used on their last turn. You may choose new targets for the Move. Mirror Move cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
    },
    "Oblivion Wing":{  
       "Type":"Flying",
@@ -2109,7 +2259,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user gains HP equal to Oblivion Wing’s Damage Roll.",
       "Contest Type":"Cool",
-      "Contest Effect":"Catching Up"
+      "Contest Effect":"Catching Up",
+      "Crits On":20
    },
    "Peck":{  
       "Type":"Flying",
@@ -2119,7 +2270,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Pluck":{  
       "Type":"Flying",
@@ -2130,7 +2282,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Pluck takes the target's Held Item or Accessory Slot Item and attaches it to Pluck's user, if the user is not holding anything.",
       "Contest Type":"Cute",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
+      "Crits On":20
    },
    "Roost":{  
       "Type":"Flying",
@@ -2139,7 +2292,7 @@
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP. If the user is a Flying Type, it loses the Flying Type until the start of their next turn.",
       "Contest Type":"Cool",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Sky Attack":{  
       "Type":"Flying",
@@ -2150,7 +2303,8 @@
       "Range":"Melee, Pass, Set-Up, Full Action",
       "Effect":"Set-Up Effect: The user is moved up 25 meters into the air. Resolution Effect: The user may shift until they are next to a legal target in the encounter. They may then shift again and pass through legal targets to attack with Sky Attack. Sky Attack Flinches a target on 17+.",
       "Contest Type":"Cool",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Sky Drop":{  
       "Type":"Flying",
@@ -2161,7 +2315,8 @@
       "Range":"Melee, 1 Target, Set-Up",
       "Effect":"Set-Up Effect: Make Sky Drop's Accuracy Check. If the user hits, the user and target are moved 25 meters into the air. The target forfeits their next turn and cannot Shift or take actions until Sky Drop is resolved. Resolution Effect: Shift while in the air and lower both the user and the target heights back to the ground. Then apply Sky Drop's damage. If the target has a Sky or Levitate Speed, Sky Drop fails to deal damage. If the user is Fainted after the Set-Up but before the Resolution, the target falls to the ground and takes damage as if Sky Drop had a Damage Base of 3 (1d6+5/8) unless they have a Sky or Levitate Speed, in which case they take no damage.",
       "Contest Type":"Smart",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Tailwind":{  
       "Type":"Flying",
@@ -2170,7 +2325,7 @@
       "Range":"Blessing",
       "Effect":"For the remainder of the encounter, all allied trainers and Pokémon gain +5 to their Initiative. Multiple instances of Tailwind cannot stack. *Grants: Guster",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
    },
    "Wing Attack":{  
       "Type":"Flying",
@@ -2180,7 +2335,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Astonish":{  
       "Type":"Ghost",
@@ -2191,7 +2347,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Astonish Flinches the target on 15+. Once per Scene, if the target is unaware of the user's presence, Astonish automatically Flinches.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Confuse Ray":{  
       "Type":"Ghost",
@@ -2201,7 +2358,7 @@
       "Range":"6, 1 Target",
       "Effect":"The target is Confused.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Curse":{  
       "Type":"Ghost",
@@ -2210,7 +2367,7 @@
       "Range":"Self",
       "Effect":"If the user is not a Ghost Type, Curse has a Frequency of EOT, and when used the user lowers its Speed by -1 Combat Stage, but raises Attack and Defense by +1 Combat Stage each. If the user is a Ghost Type, Curse has a Frequency of Scene, and when used the user loses 1/3 of their Max Hit Points and a target Pokémon or Trainer within 8 meters of the user becomes Cursed. This Hit Point loss cannot be prevented in any way.",
       "Contest Type":"Tough",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Destiny Bond":{  
       "Type":"Ghost",
@@ -2219,7 +2376,7 @@
       "Range":"Burst 10, Friendly",
       "Effect":"All enemy targets in the burst become Bound to the user until the end of your next turn. If a Bound target causes the user to Faint through a Damaging Attack, the Bound target immediately faints after their attack is resolved.",
       "Contest Type":"Smart",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
    },
    "Grudge":{  
       "Type":"Ghost",
@@ -2228,7 +2385,7 @@
       "Range":"6, 1 Target, Interrupt",
       "Effect":"You may use Grudge as an Interrupt when a Damaging Attack causes the user to faint. Grudge is activated as a Free Action (does not take up a Command.) The attack is resolved as usual, and the user Faints. The attacker that caused the user to Faint becomes Suppressed for the remainder of the encounter; switching and Taking a Breather does not end Suppression when used this way.",
       "Contest Type":"Tough",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Hex":{  
       "Type":"Ghost",
@@ -2239,7 +2396,8 @@
       "Range":"6, 1 Target",
       "Effect":"Once a Scene, if Hex's target has a Status Affliction, you may have Hex's Damage Base be 13 instead (4d10+10 / 35)",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Lick":{  
       "Type":"Ghost",
@@ -2250,7 +2408,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Lick Paralyzes the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
+      "Crits On":20
    },
    "Night Shade":{  
       "Type":"Ghost",
@@ -2260,7 +2419,8 @@
       "Range":"8, 1 Target",
       "Effect":"The target loses HP equal to the level of Night Shade's user. Do not apply weakness or resistance. Do not apply stats.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Nightmare":{  
       "Type":"Ghost",
@@ -2270,7 +2430,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"Nightmare can only hit Legal Targets that are Asleep. The target gains Bad Sleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Ominous Wind":{  
       "Type":"Ghost",
@@ -2281,7 +2441,8 @@
       "Range":"6, 1 Target, Spirit Surge",
       "Effect":"On 19+, the user has each of its stats raised by +1 Combat Stage.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
+      "Crits On":20
    },
    "Phantom Force":{  
       "Type":"Ghost",
@@ -2292,7 +2453,8 @@
       "Range":"Melee, 1 Target, Set-Up",
       "Effect":"Set-Up Effect: The user is removed from the field, and their turn ends. Resolution Effect: Phantom Force’s user appears adjacent to any legal target on the field, ignoring Movement Capabilities, and then uses Phantom Force’s attack. Phantom Force cannot be avoided by Moves with the Shield Keyword, the Dodge Ability, or similar effects, and Intercepts may not be attempted in response.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Shadow Ball":{  
       "Type":"Ghost",
@@ -2303,7 +2465,8 @@
       "Range":"8, 1 Target",
       "Effect":"Shadow Ball lowers the foe's Special Defense 1 Combat Stage on 17+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Shadow Claw":{  
       "Type":"Ghost",
@@ -2314,7 +2477,8 @@
       "Range":"Melee, Pass",
       "Effect":"Shadow Claw is a Critical Hit on 18+.",
       "Contest Type":"Cute",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":18
    },
    "Shadow Force":{  
       "Type":"Ghost",
@@ -2325,7 +2489,8 @@
       "Range":"Melee, 1 Target, Set-Up",
       "Effect":"Set-Up Effect: The user is removed from the field, and their turn ends. Resolution Effect: Shadow Force’s user appears adjacent to any legal target on the field, ignoring Movement Capabilities, and then uses Shadow Force’s attack. Shadow Force cannot be avoided by Moves with the Shield Keyword, the Dodge Ability, or similar effects, and Intercepts may not be attempted in response.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Shadow Punch":{  
       "Type":"Ghost",
@@ -2335,7 +2500,8 @@
       "Range":"6, 1 Target",
       "Effect":"Shadow Punch cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Shadow Sneak":{  
       "Type":"Ghost",
@@ -2345,7 +2511,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Priority",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Spite":{  
       "Type":"Ghost",
@@ -2354,7 +2521,7 @@
       "Range":"1 Target, Trigger",
       "Effect":"Spite may be used as a Free Action that does not take up a Command whenever the user is hit by a Move. That Move becomes Disabled for the attacker.",
       "Contest Type":"Tough",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Trick-or-Treat":{  
       "Type":"Ghost",
@@ -2364,7 +2531,7 @@
       "Range":"6, 1 Target",
       "Effect":"The target gains the Ghost Type in addition to its other Types for 5 turns.",
       "Contest Type":"Cute",
-      "Contest Effect":"Good Show!"
+      "Contest Effect":"Good Show!",
    },
    "Absorb":{  
       "Type":"Grass",
@@ -2375,7 +2542,8 @@
       "Range":"4, 1 Target",
       "Effect":"After the target takes damage, the user gains HP equal to half of the damage they dealt to the target.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Aromatherapy":{  
       "Type":"Grass",
@@ -2384,7 +2552,7 @@
       "Range":"Burst 1",
       "Effect":"All allies in the burst are cured of one status condition of their choice.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Bullet Seed":{  
       "Type":"Grass",
@@ -2394,7 +2562,8 @@
       "Class":"Physical",
       "Range":"6, 1 Target, Five Strike",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Cotton Guard":{  
       "Type":"Grass",
@@ -2403,7 +2572,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Defense 3 Combat Stages.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Cotton Spore":{  
       "Type":"Grass",
@@ -2413,7 +2582,7 @@
       "Range":"Burst 1, Powder",
       "Effect":"All legal targets have their Speed lowered 2 Combat Stages.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
    },
    "Energy Ball":{  
       "Type":"Grass",
@@ -2424,7 +2593,8 @@
       "Range":"8, 1 Target",
       "Effect":"Energy Ball lowers the foe’s Special Defense 1 Combat Stage on 17+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Forest's Curse":{  
       "Type":"Grass",
@@ -2434,7 +2604,7 @@
       "Range":"6, 1 Target",
       "Effect":"The target gains the Grass Type in addition to its other Types for 5 turns.",
       "Contest Type":"Smart",
-      "Contest Effect":"Good Show!"
+      "Contest Effect":"Good Show!",
    },
    "Frenzy Plant":{  
       "Type":"Grass",
@@ -2444,7 +2614,8 @@
       "Class":"Special",
       "Range":"3, 5 Targets, Smite, Exhaust",
       "Contest Type":"Cool",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Giga Drain":{  
       "Type":"Grass",
@@ -2455,7 +2626,8 @@
       "Range":"6, 1 Target",
       "Effect":"After the target takes damage, the user gains HP equal to half of the damage they dealt to the target.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Grass Knot":{  
       "Type":"Grass",
@@ -2466,7 +2638,8 @@
       "Range":"5, 1 Target, Weight Class",
       "Effect":"Grass Knot's Damage Base is equal to twice the target's Weight Class.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Grass Pledge":{  
       "Type":"Grass",
@@ -2477,7 +2650,8 @@
       "Range":"6, 1 Target, Pledge",
       "Effect":"If an ally uses Fire Pledge or Water Pledge, you may use Grass Pledge as Priority (Advanced) immediately after their turn to target the same foe. If used in conjunction with Fire Pledge, Fire Hazards are created in a Burst 1 around the target. If used in conjunction with Water Pledge, the target and all foes adjacent to the the target are slowed and have their Speed reduced by 2 Combat Stages. Consult the Pledge keyword for additional details.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Grasswhistle":{  
       "Type":"Grass",
@@ -2487,7 +2661,7 @@
       "Range":"6, 1 Target, Sonic",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Grassy Terrain":{  
       "Type":"Grass",
@@ -2496,7 +2670,7 @@
       "Range":"Field",
       "Effect":"The area becomes Grassy for 5 rounds. While Grassy, all Pokémon and Trainers standing on the ground recover 1/10th of their maximum Hit Points at the start of every turn, and Grass-Type attacks performed by grounded Pokémon and Trainers gain a +10 bonus to Damage Rolls.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready"
+      "Contest Effect":"Get Ready",
    },
    "Horn Leech":{  
       "Type":"Grass",
@@ -2507,7 +2681,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"After the target takes damage, the user gains HP equal to half of the damage they dealt to the target.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Ingrain":{  
       "Type":"Grass",
@@ -2516,7 +2691,7 @@
       "Range":"Self, Coat",
       "Effect":"Ingrain applies a Coat to the user, which has the following effect; the user cannot be pushed or pulled, and cannot be switched out. At the beginning of each of the user's turn, the user gains HP equal to 1/10th of its max HP.",
       "Contest Type":"Smart",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Leaf Blade":{  
       "Type":"Grass",
@@ -2527,7 +2702,8 @@
       "Range":"Melee, Pass",
       "Effect":"Leaf Blade is a Critical Hit on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":18
    },
    "Leaf Storm":{  
       "Type":"Grass",
@@ -2538,7 +2714,8 @@
       "Range":"8, Ranged Blast 3, Smite",
       "Effect":"Lower the user’s Special Attack 2 Combat Stages after damage.",
       "Contest Type":"Cute",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Leaf Tornado":{  
       "Type":"Grass",
@@ -2549,7 +2726,8 @@
       "Range":"6, Ranged Blast 3",
       "Effect":"Small or Medium targets in the central square of the blast are not hit. On 15+, all legal targets have their Accuracy lowered by -1.",
       "Contest Type":"Beauty",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Leech Seed":{  
       "Type":"Grass",
@@ -2559,7 +2737,7 @@
       "Range":"6, 1 Target",
       "Effect":"At the beginning of each of the target's turns, Leech Seed's target loses 1/10th of their full HP. Leech Seed's user then gains HP equal to the amount the target lost. Leech Seed lasts until the target faints or is returned to a Poké Ball. Grass Types and targets immune to Grass Attacks are immune to Leech Seed",
       "Contest Type":"Smart",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Magical Leaf":{  
       "Type":"Grass",
@@ -2569,7 +2747,8 @@
       "Range":"8, 1 Target",
       "Effect":"Magical Leaf cannot miss.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Mega Drain":{  
       "Type":"Grass",
@@ -2580,7 +2759,8 @@
       "Range":"6, 1 Target",
       "Effect":"After the target takes damage, the user gains HP equal to half of the damage they dealt to the target.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Needle Arm":{  
       "Type":"Grass",
@@ -2591,7 +2771,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Needle Arm Flinches the target on 15+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Petal Blizzard":{  
       "Type":"Grass",
@@ -2601,7 +2782,8 @@
       "Class":"Physical",
       "Range":"Burst 1",
       "Contest Type":"Beauty",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Petal Dance":{  
       "Type":"Grass",
@@ -2612,7 +2794,8 @@
       "Range":"Melee, All Adjacent Foes, Smite",
       "Effect":"After damage is dealt, the user becomes Enraged and Confused.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Power Whip":{  
       "Type":"Grass",
@@ -2623,7 +2806,8 @@
       "Range":"8, 1 Target, Smite",
       "Effect":"*Grants: Threaded",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Razor Leaf":{  
       "Type":"Grass",
@@ -2634,7 +2818,8 @@
       "Range":"Cone 2",
       "Effect":"Razor Leaf is a Critical Hit on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":18
    },
    "Seed Bomb":{  
       "Type":"Grass",
@@ -2644,7 +2829,8 @@
       "Class":"Physical",
       "Range":"8, 1 Target",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Seed Flare":{  
       "Type":"Grass",
@@ -2655,7 +2841,8 @@
       "Range":"6, Ranged Blast 3",
       "Effect":"All Legal Targets have their Special Defense lowered 1 Combat Stage.",
       "Contest Type":"Cool",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Sleep Powder":{  
       "Type":"Grass",
@@ -2665,7 +2852,7 @@
       "Range":"4, 1 Target, Powder",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Solar Beam":{  
       "Type":"Grass",
@@ -2676,7 +2863,8 @@
       "Range":"Line 6, 1 Target, Set-Up",
       "Effect":"Set-Up Effect: If the weather is not Sunny, the user’s turn ends. If the weather is Sunny, immediately proceed to the Resolution Effect instead and this Move loses the Set-Up keyword. Resolution Effect: The user attacks with Solar Beam. If the weather is Rainy, Sandstorming, or Hailing, Solar Beam’s Damage Base is lowered to 6 (2d6+8 / 15).",
       "Contest Type":"Cool",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Spiky Shield":{  
       "Type":"Grass",
@@ -2685,7 +2873,7 @@
       "Range":"Self, Interrupt, Shield, Trigger",
       "Effect":"If the user is hit by an attack, the user may use Spiky Shield. The user is instead not hit by the Move. You do not take any damage nor are you affected by any of the Move’s effects. In addition, if the triggering attack was Melee-ranged, the attacker loses Hit Points equal to 1/10th of their Max Hit Points.",
       "Contest Type":"Tough",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Spore":{  
       "Type":"Grass",
@@ -2694,7 +2882,7 @@
       "Range":"4, 1 Target, Powder",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Stun Spore":{  
       "Type":"Grass",
@@ -2704,7 +2892,7 @@
       "Range":"6, 1 Target, Powder",
       "Effect":"The target is Paralyzed.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Synthesis":{  
       "Type":"Grass",
@@ -2713,7 +2901,7 @@
       "Range":"Self",
       "Effect":"The user regains Hit Points equal to half of its full Hit Point value. If it is Sunny, the user gains 2/3 of its full Hit Point value. If it is Rainy, Sand Storming, or Hailing, the user gains 1/4 of its full Hit Point value.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Vine Whip":{  
       "Type":"Grass",
@@ -2724,7 +2912,8 @@
       "Range":"4, 1 Target",
       "Effect":"*Grants: Threaded",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Wood Hammer":{  
       "Type":"Grass",
@@ -2734,7 +2923,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash, Recoil 1/3",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Worry Seed":{  
       "Type":"Grass",
@@ -2744,7 +2934,7 @@
       "Range":"8, 1 Target",
       "Effect":"The target's Ability is replaced with Insomnia. If the target has multiple Abilities, Worry Seed only replaces one, chosen at random.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Bone Club":{  
       "Type":"Ground",
@@ -2755,7 +2945,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Bone Club Flinches the target on 18+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Bone Rush":{  
       "Type":"Ground",
@@ -2765,7 +2956,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Five Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Bonemerang":{  
       "Type":"Ground",
@@ -2775,7 +2967,8 @@
       "Class":"Physical",
       "Range":"6, 1 Target, Double Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Bulldoze":{  
       "Type":"Ground",
@@ -2786,7 +2979,8 @@
       "Range":"Burst 1",
       "Effect":"All Legal Targets are lowered 1 Speed Combat Stage.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Dig":{  
       "Type":"Ground",
@@ -2797,7 +2991,8 @@
       "Range":"Burst 1, Set-Up, Full Action, Groundsource",
       "Effect":"Set-Up Effect: The user shifts 25 meters underground and their turn ends. Resolution Effect: The user may shift horizontally using their burrow or overland speed, and then shifts 25 meters straight up. Upon reaching the surface, the user attacks with Dig, creating a Burst 1. *Grants: Burrow +3",
       "Contest Type":"Smart",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Drill Run":{  
       "Type":"Ground",
@@ -2808,7 +3003,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Drill Run is a Critical Hit on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":18
    },
    "Earth Power":{  
       "Type":"Ground",
@@ -2819,7 +3015,8 @@
       "Range":"6, 1 Target, Groundsource",
       "Effect":"Earth Power lowers the Special Defense of all Legal Targets 1 Combat Stage on 16+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Earthquake":{  
       "Type":"Ground",
@@ -2830,7 +3027,8 @@
       "Range":"Burst 3, Groundsource",
       "Effect":"Earthquake can hit targets that are underground, including those using the Move Dig. *Grants Groundshaper",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Fissure":{  
       "Type":"Ground",
@@ -2839,7 +3037,7 @@
       "Range":"5, 1 Target, Execute, Groundsource",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level. *Grants: Groundshaper",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
    },
    "Land's Wrath":{  
       "Type":"Ground",
@@ -2850,7 +3048,8 @@
       "Range":"Burst 5, Friendly, Groundsource",
       "Effect":"*Grants: Groundshaper",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Magnitude":{  
       "Type":"Ground",
@@ -2861,7 +3060,8 @@
       "Range":"Burst 2, Groundsource",
       "Effect":"When you use Magnitude, roll 1d6. Magnitude’s Damage Base is equal to 5+X, where X is the value of the d6. Magnitude can hit targets that are underground, including those using the Move Dig. *Grants: Groundshaper",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Mud Bomb":{  
       "Type":"Ground",
@@ -2872,7 +3072,8 @@
       "Range":"6, 1 Target",
       "Effect":"The target's Accuracy is lowered by -1 on 16+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Mud Shot":{  
       "Type":"Ground",
@@ -2883,7 +3084,8 @@
       "Range":"3, 1 Target",
       "Effect":"The target's Speed is lowed by -1 Combat Stage.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Mud Sport":{  
       "Type":"Ground",
@@ -2892,7 +3094,7 @@
       "Range":"Burst 2",
       "Effect":"All targets in the burst, including the user, gain a Coat which grants them 1 Step of Resistance to Electric Type Moves. After a target has been hit by a damaging Electric Type Move, the coat is removed.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Mud-Slap":{  
       "Type":"Ground",
@@ -2903,7 +3105,8 @@
       "Range":"3, 1 Target",
       "Effect":"The target's Accuracy is lowered by -1.",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Preicpice Blades":{  
       "Type":"Ground",
@@ -2913,7 +3116,8 @@
       "Class":"Physical",
       "Range":"Burst 1, Smite",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Rototiller":{  
       "Type":"Ground",
@@ -2922,7 +3126,7 @@
       "Range":"Burst 2",
       "Effect":"All Grass-type Pokémon in the area raise their Attack and Special Attack 1 Combat Stage.",
       "Contest Type":"Tough",
-      "Contest Effect":"Special Attention"
+      "Contest Effect":"Special Attention",
    },
    "Sand Tomb":{  
       "Type":"Ground",
@@ -2933,7 +3137,8 @@
       "Range":"5, 1 Target",
       "Effect":"The target is put in a Vortex.",
       "Contest Type":"Smart",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Sand Attack":{  
       "Type":"Ground",
@@ -2943,7 +3148,7 @@
       "Range":"2, 1 Target",
       "Effect":"The target is Blinded until the end of their next turn.",
       "Contest Type":"Cute",
-      "Contest Effect":" Excitement"
+      "Contest Effect":" Excitement",
    },
    "Spikes":{  
       "Type":"Ground",
@@ -2952,7 +3157,7 @@
       "Range":"6, Hazard",
       "Effect":"Set 8 square meters of Spikes within the range such that all 8 meters are adjacent with at least one other space of Spikes. Spikes cause terrain to count as Slow Terrain, and a grounded foe that runs into the hazards will lose 1/10th of their full HP and become Slowed until the end of their next turn.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Aurora Beam":{  
       "Type":"Ice",
@@ -2963,7 +3168,8 @@
       "Range":"6, 1 Target",
       "Effect":"Aurora Beam lowers the target's Attack 1 Combat Stage on 18+. *Grants: Freezer",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Avalanche":{  
       "Type":"Ice",
@@ -2974,7 +3180,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"When declaring Avalanche, the user does nothing and may not Shift. At the end of the round, the user may Shift and use Avalanche. If the target damaged the user this round, Avalanche has a Damage Base of 12 (4d10+15 / 40).",
       "Contest Type":"Cool",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Blizzard":{  
       "Type":"Ice",
@@ -2985,7 +3192,8 @@
       "Range":"4, Ranged Blast 2, Smite",
       "Effect":"Blizzard Freezes all legal target on 15+. If the target is in Hailing Weather, Blizzard cannot miss.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Freeze-Dry":{  
       "Type":"Ice",
@@ -2996,7 +3204,8 @@
       "Range":"6, 1 Target",
       "Effect":"When calculating Weakness and Resistance for Freeze-Dry, Water-Typed targets calculate damage as if Water was weak to Ice.",
       "Contest Type":"Tough",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Freeze Shock":{  
       "Type":"Ice",
@@ -3007,7 +3216,8 @@
       "Range":"10, 1 Target, Set-Up, Full Action",
       "Effect":"Set-Up Effect: The user may shift, then ends their turn. Resolution Effect: The user attacks with Freeze Shock. Freeze Shock paralyzes on 15+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Frost Breath":{  
       "Type":"Ice",
@@ -3018,7 +3228,8 @@
       "Range":"4, 1 Target",
       "Effect":"If Frost Breath hits, it is a Critical Hit. *Grants: Freezer",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":0
    },
    "Glaciate":{  
       "Type":"Ice",
@@ -3029,7 +3240,8 @@
       "Range":"Burst 2",
       "Effect":"All Legal Targets have their Speed lowered 1 Combat Stage. On an Even-Numbered Roll, all Legal Targets on the ground are Slowed.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Hail":{  
       "Type":"Ice",
@@ -3038,7 +3250,7 @@
       "Range":"Field, Weather",
       "Effect":"The weather changes to Hail for 5 rounds. While it is Hailing, all non-Ice Type Pokémon lose a Tick of Hit Points at the beginning of their turn.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Haze":{  
       "Type":"Ice",
@@ -3047,7 +3259,7 @@
       "Range":"Field",
       "Effect":"The Combat Stages of the user and all Pokémon and Trainers in the encounter are set to their default state (usually 0).",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Ice Ball":{  
       "Type":"Ice",
@@ -3058,7 +3270,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user continues to use Ice Ball on each of its turns until they miss any target with Ice Ball or are not able to hit any target with Ice Ball during their turn. Each successive use of Ice Ball increases Ice Ball's Damage Base by +3 to a maximum of DB 15.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Ice Beam":{  
       "Type":"Ice",
@@ -3069,7 +3282,8 @@
       "Range":"6, 1 Target",
       "Effect":"Ice Beam Freezes on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Ice Burn":{  
       "Type":"Ice",
@@ -3080,7 +3294,8 @@
       "Range":"10, 1 Target, Set-Up, Full Action",
       "Effect":"Set-Up Effect: The user may shift, then ends their turn. Resolution Effect: The user attacks with Ice Burn. Ice Burn Burns on 15+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Ice Fang":{  
       "Type":"Ice",
@@ -3091,7 +3306,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Ice Fang Freezes or Flinches on 18-19 during Accuracy Check; flip a coin to determine whether the foe becomes Frozen or Flinched. On 20 during Accuracy Check, the foe is both Frozen and Flinched.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Ice Punch":{  
       "Type":"Ice",
@@ -3102,7 +3318,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Ice Punch Freezes the target on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Ice Shard":{  
       "Type":"Ice",
@@ -3112,7 +3329,8 @@
       "Class":"Physical",
       "Range":"4, 1 Target, Priority",
       "Contest Type":"Beauty",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Icicle Crash":{  
       "Type":"Ice",
@@ -3123,7 +3341,8 @@
       "Range":"6, 1 Target",
       "Effect":"Icicle Crash Flinches the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Icicle Spear":{  
       "Type":"Ice",
@@ -3133,7 +3352,8 @@
       "Class":"Physical",
       "Range":"6, 1 Target, Five Strike",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Icy Wind":{  
       "Type":"Ice",
@@ -3144,7 +3364,8 @@
       "Range":"Cone 2",
       "Effect":"All Legal Targets have their Speed lowered 1 Combat Stage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Mist":{  
       "Type":"Ice",
@@ -3153,7 +3374,7 @@
       "Range":"Blessing",
       "Effect":"Any user affected by Mist may activate it when having Combat Stages lowered by any effect; if they do, those Combat Stages are instead not lowered. Mist may be activated 3 times and then disappears.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Powder Snow":{  
       "Type":"Ice",
@@ -3164,7 +3385,8 @@
       "Range":"Line 4",
       "Effect":"Powder Snow Freezes all Legal Targets on 19+. *Grants: Freezer",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Sheer Cold":{  
       "Type":"Ice",
@@ -3173,7 +3395,7 @@
       "Range":"4, 1 Target, Execute",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level. *Grants: Freezer",
       "Contest Type":"Beauty",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
    },
    "Acupressure":{  
       "Type":"Normal",
@@ -3183,7 +3405,7 @@
       "Range":"Melee, 1 Target or Self",
       "Effect":"Roll 1d6. On a result of 1, raise the target’s Attack by +2 CS. On a result of 2, raise the target’s Defense by +2 CS. On a result of 3, raise the target’s Special Attack by +2 CS. On a result of 4, raise the target’s Special Defense by +2 CS. On a result of 5, raise the target’s Speed by +2 CS. On a result of 6, raise the target’s Accuracy by +2.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "After You":{  
       "Type":"Normal",
@@ -3192,7 +3414,7 @@
       "Range":"6, 1 Target",
       "Effect":"After You is a Swift Action. The target takes their turn for the round immediately after the user finishes their turn, ignoring Initiative. After You may only affect a target that has not yet acted that round and can only affect willing targets.",
       "Contest Type":"Smart",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
    },
    "Assist":{  
       "Type":"Normal",
@@ -3201,7 +3423,7 @@
       "Range":"Self",
       "Effect":"Randomly select another Pokémon on the user’s roster and then randomly select a Move that Pokémon knows. Assist’s user uses that Move immediately.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Attract":{  
       "Type":"Normal",
@@ -3211,7 +3433,7 @@
       "Range":"3, 1 Target, Social",
       "Effect":"Attract Infatuates the target if its gender is the opposite of the user’s. Attract fails when used by or against Genderless targets.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Barrage":{  
       "Type":"Normal",
@@ -3221,7 +3443,8 @@
       "Class":"Physical",
       "Range":"6, 1 Target, Five Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Baton Pass":{  
       "Type":"Normal",
@@ -3230,7 +3453,7 @@
       "Range":"Self",
       "Effect":"The user is replaced with another Pokémon from their trainer’s roster. All Combat Stage, Coats, and [Stratagems] on Baton Pass’ user are transferred to the replacement. Baton Pass may be used to switch even if the user is Trapped.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Belly Drum":{  
       "Type":"Normal",
@@ -3239,7 +3462,7 @@
       "Range":"Self",
       "Effect":"The user gains +6 Attack CS and loses HP equal to 1/2 of their Max HP.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Bestow":{  
       "Type":"Normal",
@@ -3248,7 +3471,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user gives its held item to the target, unless the target is already holding an item. Using Bestow is a Swift Action.",
       "Contest Type":"Cute",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Bide":{  
       "Type":"Normal",
@@ -3258,7 +3481,8 @@
       "Range":"Burst 1, Friendly",
       "Effect":"The user may use Bide as a Reaction Move upon being Hit by a Damaging Move. During their next available turn, the user may Shift and then use Bide, causing all Adjacent foes to lose X HP, where X is the amount of Damage taken since declaring use of Bide (Loss of life through effects such as Poison is not ‘Damage’).",
       "Contest Type":"Tough",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Bind":{  
       "Type":"Normal",
@@ -3267,7 +3491,8 @@
       "Range":"--",
       "Effect":"The user gains a +1 Bonus to Accuracy Rolls made to initiate Grapple Maneuvers, and +2 to Skill Checks made to initiate Grapple Maneuvers or gain Dominance. Whenever the user gains Dominance in a Grapple, the target of the Grapple loses a Tick of Hit Points.",
       "Contest Type":"Tough",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Block":{  
       "Type":"Normal",
@@ -3277,7 +3502,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target is Stuck and Trapped until the beginning of your next turn.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Body Slam":{  
       "Type":"Normal",
@@ -3288,7 +3513,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Body Slam Paralyzes the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Boomburst":{  
       "Type":"Normal",
@@ -3298,7 +3524,8 @@
       "Class":"Special",
       "Range":"Burst 1, Sonic",
       "Contest Type":"Cool",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Camouflage":{  
       "Type":"Normal",
@@ -3307,7 +3534,7 @@
       "Range":"Self",
       "Effect":"The user changes their Type to match the field. Forests and grassy areas change the user into a Grass Type. Watery areas change the user into a Water Type. Caves and Mountains could change the user into a Rock or Ground Type. An icy terrain would turn the user into an Ice Type. A building may change the user into a Steel or Normal Type. Weather affects what Type the user becomes. Use common sense; if you are having difficult determining what Type the user should become, consult the GM. *Grants Blender",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Captivate":{  
       "Type":"Normal",
@@ -3317,7 +3544,7 @@
       "Range":"Cone 2, Friendly, Social",
       "Effect":"Captivate lowers the target's Special Attack by -2 CS. Captivate may not affect something that is the same gender as the user or something that is genderless.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Chip Away":{  
       "Type":"Normal",
@@ -3328,7 +3555,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Ignore any Armor, Damage Reduction, or changes in the target's Defense or Special Defense (such as from Combat Stages) when calculating damage.",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Comet Punch":{  
       "Type":"Normal",
@@ -3338,7 +3566,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Five Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Confide":{  
       "Type":"Normal",
@@ -3348,7 +3577,7 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Lower the target's Special Attack by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Constrict":{  
       "Type":"Normal",
@@ -3359,7 +3588,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Lower the target’s Speed by -1 CS. Constrict may be used as a Swift Action against targets the user is Grappling and automatically hits when performed this way.",
       "Contest Type":"Tough",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Conversion":{  
       "Type":"Normal",
@@ -3368,7 +3598,7 @@
       "Range":"Self",
       "Effect":"The user becomes the elemental Type of their choice as long as they have a Move that is the same elemental Type until the end of the encounter. Replace all other Types.",
       "Contest Type":"Beauty",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
    },
    "Conversion2":{  
       "Type":"Normal",
@@ -3377,7 +3607,7 @@
       "Range":"Self",
       "Effect":"The user becomes the elemental Type of their choice as long as the Type resists the elemental Type of the Move it last took damage from until the end of the encounter. Replace all other Types.",
       "Contest Type":"Beauty",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
    },
    "Copycat":{  
       "Type":"Normal",
@@ -3386,7 +3616,7 @@
       "Range":"4, 1 Target",
       "Effect":"Use the Move the target has used on their last turn. You may choose new targets for the Move. Copycat cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Covet":{  
       "Type":"Normal",
@@ -3397,7 +3627,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Covet takes the target’s Held Item or Accessory Slot Item and attaches it to Covet’s user, if the user is not holding anything.",
       "Contest Type":"Cute",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
+      "Crits On":20
    },
    "Crush Claw":{  
       "Type":"Normal",
@@ -3408,7 +3639,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Crush Claw lowers the target’s Defense by -1 CS on Even-Numbered Rolls.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Crush Grip":{  
       "Type":"Normal",
@@ -3419,7 +3651,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"For every 10% the target is below their full Hit Points, Crush Grip's Damage Base is reduced by 1.",
       "Contest Type":"Tough",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Cut":{  
       "Type":"Normal",
@@ -3430,7 +3663,8 @@
       "Range":"Melee, Pass",
       "Effect":"Cut ignores up to 5 Damage Reduction (Defenses are not Damage Reduction.)",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Defense Curl":{  
       "Type":"Normal",
@@ -3439,7 +3673,7 @@
       "Range":"Self",
       "Effect":"The user becomes Curled Up. While Curled Up, the user becomes immune to Critical Hits and gains 10 Damage Reduction. However, while Curled Up, the user is Slowed and their Accuracy is lowered by -4. The user may stop being Curled Up as a Swift Action. If the user has Rollout or Ice Ball in their Move List, they do not become Slowed while Curled Up. Furthermore, when using the Moves Rollout or Ice Ball while Curled Up, the user gains a +10 bonus to the damage rolls of those Moves and does not suffer Accuracy Penalties from being Curled Up.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Disable":{  
       "Type":"Normal",
@@ -3448,7 +3682,7 @@
       "Range":"1 Target, Trigger",
       "Effect":"Disable may be used as a Free Action that does not take up a Command whenever the user is hit by a Move. That Move becomes Disabled for the attacker.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Dizzy Punch":{  
       "Type":"Normal",
@@ -3459,7 +3693,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Dizzy Punch Confuses the target on 17+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
+      "Crits On":20
    },
    "Double Hit":{  
       "Type":"Normal",
@@ -3469,7 +3704,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Double Strike",
       "Contest Type":"Smart",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Double Team":{  
       "Type":"Normal",
@@ -3478,7 +3714,7 @@
       "Range":"Self, Illusion, Coat",
       "Effect":"The user gains 3 activations of Double Team. The user may either activate Double Team when being targeted by an attack to increase their Evasion by +2 against that attack or when making an attack to increase their Accuracy by +2 for that attack.",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
    },
    "Double-Edge":{  
       "Type":"Normal",
@@ -3488,7 +3724,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash, Recoil 1/3",
       "Contest Type":"Tough",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Double Slap":{  
       "Type":"Normal",
@@ -3498,7 +3735,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Five Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Echoed Voice":{  
       "Type":"Normal",
@@ -3509,7 +3747,8 @@
       "Range":"3, 1 Target, Sonic",
       "Effect":"If Echoed Voice was used by any Pokémon or Trainer in the Encounter on the previous round, increase its Damage Base by +4. If Echoed Voice was used by any Pokémon or Trainers during both the previous two rounds, increase its Damage Base by +8.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Egg Bomb":{  
       "Type":"Normal",
@@ -3519,7 +3758,8 @@
       "Class":"Physical",
       "Range":"5, Blast 2",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Encore":{  
       "Type":"Normal",
@@ -3529,7 +3769,7 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Roll 1d6. On a result of 1 or 2, the target becomes Confused; on a result of 3 or 4 the target becomes Suppressed; on a result of 5 or 6 the target becomes Enraged.",
       "Contest Type":"Cute",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Endeavor":{  
       "Type":"Normal",
@@ -3540,7 +3780,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"The target loses a Tick of Hit Points for each Injury the user has.",
       "Contest Type":"Tough",
-      "Contest Effect":"Double TIme"
+      "Contest Effect":"Double TIme",
+      "Crits On":20
    },
    "Endure":{  
       "Type":"Normal",
@@ -3549,7 +3790,7 @@
       "Range":"Self, Reaction, Trigger",
       "Effect":"If the user is hit by a damaging Move, you may use Endure as a Free Action. If the Move would bring Endure's user down to 0 HP or less, Endure's user instead is set to 1 HP.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Entrainment":{  
       "Type":"Normal",
@@ -3559,7 +3800,7 @@
       "Range":"4, 1 Target",
       "Effect":"The target gains one of the user's Abilities for 3 turns.",
       "Contest Type":"Cute",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
    },
    "Explosion":{  
       "Type":"Normal",
@@ -3570,7 +3811,8 @@
       "Range":"Burst 2",
       "Effect":"The user's HP is set to -50% of their full HP. This HP loss cannot be prevented or reduced in any way. The user's loyalty toward its trainer may be lowered.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Extreme Speed":{  
       "Type":"Normal",
@@ -3580,7 +3822,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash, Priority",
       "Contest Type":"Cool",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Facade":{  
       "Type":"Normal",
@@ -3591,7 +3834,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the user is afflicted with a Persistent Status Affliction, Facade's Damage Base is doubled to DB 14 (4d10+15 / 40).",
       "Contest Type":"Cute",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
+      "Crits On":20
    },
    "Façade":{  
       "Type":"Normal",
@@ -3602,7 +3846,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the user is afflicted with a Persistent Status Affliction, Façade’s Damage Base is doubled to DB 14 (4d10+15 / 40).",
       "Contest Type":"Cute",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
+      "Crits On":20
    },
    "Fake Out":{  
       "Type":"Normal",
@@ -3613,7 +3858,8 @@
       "Range":"Melee, 1 Target, Priority",
       "Effect":"You may only use Fake Out with Priority upon joining an encounter; if you do, Fake Out Flinches the target. Switching out resets the requirement of joining an encounter.",
       "Contest Type":"Cute",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "False Swipe":{  
       "Type":"Normal",
@@ -3624,7 +3870,8 @@
       "Range":"Melee, Pass",
       "Effect":"False Swipe's damage cannot bring a target lower than 1 HP.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
+      "Crits On":20
    },
    "Feint":{  
       "Type":"Normal",
@@ -3633,7 +3880,7 @@
       "Range":"Trigger",
       "Effect":"If a foe uses a Move with the Shield Keyword in response to one of your actions, you may activate Feint to cause the triggering Move to Fail. Feint is activated as a Free Action.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Flail":{  
       "Type":"Normal",
@@ -3644,7 +3891,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"For each Injury the user has, Flail's Damage Base is increased by +1.",
       "Contest Type":"Cute",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
+      "Crits On":20
    },
    "Flash":{  
       "Type":"Normal",
@@ -3654,7 +3902,7 @@
       "Range":"Cone 2",
       "Effect":"Lower the Accuracy of all legal targets by -1. *Grants Glow",
       "Contest Type":"Beauty",
-      "Contest Effect":" Unsettling"
+      "Contest Effect":" Unsettling",
    },
    "Focus Energy":{  
       "Type":"Normal",
@@ -3663,7 +3911,7 @@
       "Range":"Self",
       "Effect":"The user becomes Pumped. While Pumped, the user's Critical Range is extended by 2, or 18+ if the Critical Range is not otherwise extended. Being switched will cause this effect to end.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Follow Me":{  
       "Type":"Normal",
@@ -3672,7 +3920,7 @@
       "Range":"Burst 5, Social",
       "Effect":"Until the end of the user's next turn, all Foes must target the user when using a Move that targets their opponents. This effect ends if the user is Fainted or Switched out.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Foresight":{  
       "Type":"Normal",
@@ -3681,7 +3929,7 @@
       "Range":"Self, Swift Action",
       "Effect":"Foresight may be activated as a Swift Action on the user’s turn. For the rest of the turn, the user’s Normal-Type and Fighting-Type Moves can hit and affect Ghost-Type targets, and the user can see through the Illusion Ability, Moves with the Illusion keyword, and effects created by the Illusionist Capability, ignoring all effects from those.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Frustration":{  
       "Type":"Normal",
@@ -3692,7 +3940,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Frustration's Damage Base is equal to 9 minus the user's Loyalty Value. Using Frustration may make your Pokémon dislike you.",
       "Contest Type":"Cute",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Fury Attack":{  
       "Type":"Normal",
@@ -3702,7 +3951,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Five Strike",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Fury Swipes":{  
       "Type":"Normal",
@@ -3712,7 +3962,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Five Strike",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Giga Impact":{  
       "Type":"Normal",
@@ -3722,7 +3973,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash, Exhaust, Smite",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Glare":{  
       "Type":"Normal",
@@ -3732,7 +3984,7 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Glare Paralyzes the target.",
       "Contest Type":"Tough",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Growl":{  
       "Type":"Normal",
@@ -3742,7 +3994,7 @@
       "Range":"Burst 1, Friendly, Sonic, Social",
       "Effect":"Lower the Attack of all legal targets by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Growth":{  
       "Type":"Normal",
@@ -3751,7 +4003,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Attack and Special Attack by +1 CS each. If it is Sunny, double the amount of Combat Stages gained. *Grants Inflatable",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Guillotine":{  
       "Type":"Normal",
@@ -3760,7 +4012,7 @@
       "Range":"Melee, 1 Target, Execute",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level.",
       "Contest Type":"Cool",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
    },
    "Harden":{  
       "Type":"Normal",
@@ -3769,7 +4021,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Defense by +1 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Headbutt":{  
       "Type":"Normal",
@@ -3780,7 +4032,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Headbutt Flinches the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Head Charge":{  
       "Type":"Normal",
@@ -3791,7 +4044,8 @@
       "Range":"Melee, 1 Target, Push, Recoil 1/3",
       "Effect":"The target is Pushed back 2 meters.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Heal Bell":{  
       "Type":"Normal",
@@ -3800,7 +4054,7 @@
       "Range":"Burst 3, Sonic",
       "Effect":"All targets are cured of any Persistent Status ailments.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Helping Hand":{  
       "Type":"Normal",
@@ -3809,7 +4063,7 @@
       "Range":"4, 1 Target, Priority",
       "Effect":"Helping Hand grants the target +2 on its next Accuracy Roll this round, and +10 to its next Damage Roll this round.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Hidden Power":{  
       "Type":"Normal",
@@ -3820,7 +4074,8 @@
       "Range":"Burst 1",
       "Effect":"When a Pokémon first obtains the Move Hidden Power, roll 1d20. Hidden Power’s Elemental Type will be changed from Normal to Bug on a result of 1; Dark on 2; Dragon on 3; Electric on 4; Fairy on 5; Fighting on 6; Fire on 7; Flying on 8; Ghost on 9; Grass on 10; Ground on 11; Ice on 12; Normal on 13; Poison on 14; Psychic on 15; Rock on 16; Steel on 17; Water on 18; and on 19 or 20, reroll until you roll another number. This effect is permanent – if Hidden Power is forgotten and relearned, the chosen Type remains the same.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hold Hands":{  
       "Type":"Normal",
@@ -3829,7 +4084,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"Both the user and the target become Cheered. They may give up the Cheered condition when making a Save Check to roll twice and take the best result.",
       "Contest Type":"?",
-      "Contest Effect":"?"
+      "Contest Effect":"?",
    },
    "Horn Attack":{  
       "Type":"Normal",
@@ -3839,7 +4094,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Dash",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Horn Drill":{  
       "Type":"Normal",
@@ -3848,7 +4104,7 @@
       "Range":"Melee, 1 Target, Execute",
       "Effect":"Roll 1d100. This roll may not be modified in any way. If you roll X or lower, the target Faints. X is equal to 30 + The User's Level - The Target's Level.",
       "Contest Type":"Cool",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
    },
    "Howl":{  
       "Type":"Normal",
@@ -3857,7 +4113,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack by +1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Hyper Beam":{  
       "Type":"Normal",
@@ -3867,7 +4123,8 @@
       "Class":"Special",
       "Range":"10, 1 Target, Exhaust, Smite",
       "Contest Type":"Cool",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Hyper Fang":{  
       "Type":"Normal",
@@ -3878,7 +4135,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Hyper Fang Flinches the target on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Hyper Voice":{  
       "Type":"Normal",
@@ -3889,7 +4147,8 @@
       "Range":"Close Blast 3, Sonic, Smite",
       "Effect":"All legal targets are pushed back to the squares immediately outside the blast, away from the user.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Judgement":{  
       "Type":"Normal",
@@ -3900,7 +4159,8 @@
       "Range":"6, Ranged Blast 3, Smite",
       "Effect":"Judgment's Type can be whatever Elemental Type the user wants it to be.",
       "Contest Type":"Smart",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
+      "Crits On":20
    },
    "Last Resort":{  
       "Type":"Normal",
@@ -3911,7 +4171,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Last Resort can only be used after the user has performed 5 other different Moves in its Move List during a single fight, without being switched out.",
       "Contest Type":"Cute",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Leer":{  
       "Type":"Normal",
@@ -3921,7 +4182,7 @@
       "Range":"Cone 2, Friendly, Social",
       "Effect":"All legal targets have their Defense lowered by -1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Lock-On":{  
       "Type":"Normal",
@@ -3930,7 +4191,7 @@
       "Range":"10, 1 Target",
       "Effect":"The target is Locked-On. The next Move that the user uses against the Target that requires an Accuracy Check cannot miss. Lock-On's effect, on both the User and Target, can be passed by Baton Pass.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Lovely Kiss":{  
       "Type":"Normal",
@@ -3940,7 +4201,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"The target fall Asleep.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Lucky Chant":{  
       "Type":"Normal",
@@ -3949,7 +4210,7 @@
       "Range":"Blessing",
       "Effect":"Any user affected by Lucky Chant may activate it when receiving a Critical Hit to cause the attack to instead deal damage as if it was not a Critical Hit. Lucky Chant may be activated 3 times and then disappears.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Me First":{  
       "Type":"Normal",
@@ -3958,7 +4219,7 @@
       "Range":"Self, Trigger, Interrupt",
       "Effect":"If an opponent declares a Damaging Attack against the user, and Me First’s user has a higher Speed stat then the target, the user may use Me First as an Interrupt. The User will then use the same Move the triggering foe was about to use on that foe.",
       "Contest Type":"Cute",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
    },
    "Mean Look":{  
       "Type":"Normal",
@@ -3967,7 +4228,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"The Target becomes Trapped and Slowed for the remainder of the encounter.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Mega Kick":{  
       "Type":"Normal",
@@ -3978,7 +4239,8 @@
       "Range":"Melee, 1 Target, Dash, Push, Smite",
       "Effect":"The target is Pushed 2 meters.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Mega Punch":{  
       "Type":"Normal",
@@ -3988,7 +4250,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Metronome":{  
       "Type":"Normal",
@@ -3997,7 +4260,7 @@
       "Range":"Self",
       "Effect":"Metronome randomly uses any other Move except for After You, Assist, Bestow, Copycat, Counter, Covet, Crafty Shield, Destiny Bond, Detect, Endure, Feint, Focus Punch, Follow Me, Helping Hand, King’s Shield, Metronome, Me First, Mimic, Mirror Coat, Mirror Move, Protect, Quash, Quick Guard, Rage Powder, Sketch, Sleep Talk, Snatch, Snore, Spiky Shield, Switcheroo, Thief, Transform, Trick, and Wide Guard. The GM helps to pick the random Move.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Milk Drink":{  
       "Type":"Normal",
@@ -4006,7 +4269,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target regains HP equal to half of its full HP. The user may target themselves with Milk Drink.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Mimic":{  
       "Type":"Normal",
@@ -4015,7 +4278,7 @@
       "Range":"6, 1 Target",
       "Effect":"Choose a Move that the target has used during the encounter. For the remainder of the encounter, that Move replaces Mimic on the user’s Move List. Mimic cannot miss.",
       "Contest Type":"Cute",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Mind Reader":{  
       "Type":"Normal",
@@ -4024,7 +4287,7 @@
       "Range":"6, 1 Target",
       "Effect":"The target becomes Read to the user until the end of the user’s next turn. The user may end this effect when making an Attack on the user, causing that attack to automatically hit; OR when the Read target uses an Attack against the user, causing that attack to automatically miss. If the user has the Telepathy Capability, the user automatically succeeds on a mindreading attempt against the target, and may listen to the target’s surface thoughts as long as they remain Read. Mind Reader automatically misses against targets with the Mindlock Capability.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Minimize":{  
       "Type":"Normal",
@@ -4033,7 +4296,7 @@
       "Range":"Self",
       "Effect":"The user gains +4 Evasion, and the user's size is lowered to Small for the remainder of the encounter. *Grants Shrinkable",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Morning Sun":{  
       "Type":"Normal",
@@ -4042,7 +4305,7 @@
       "Range":"Self",
       "Effect":"The user regains Hit Points equal to half of its full Hit Point value. If it is Sunny, the user gains 2/3 of its full Hit Point value. If it is Rainy, Sand Storming or Hailing the user gains 1/4 of their full Hit Point value.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Natural Gift":{  
       "Type":"Normal",
@@ -4053,7 +4316,8 @@
       "Range":"6, 1 Target, Berry",
       "Effect":"Refer to the Move Keywords Berry list. Natural Gift deals damage according to the Berry list and Natural Gift’s Type is also defined there. The Berry’s Digestion/Food Buff is nullified and is not used.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Nature Power":{  
       "Type":"Normal",
@@ -4064,7 +4328,7 @@
       "Range":"See Effect",
       "Effect":"Nature Power uses a Move defined by the Environ keyword.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Noble Roar":{  
       "Type":"Normal",
@@ -4074,7 +4338,7 @@
       "Range":"Burst 1, Sonic, Friendly, Social",
       "Effect":"Noble Roar lowers all legal targets’ Attack and Special Attack by +1 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Odor Sleuth":{  
       "Type":"Normal",
@@ -4083,7 +4347,7 @@
       "Range":"Self, Swift Action",
       "Effect":"Odor Sleuth may be activated as a Swift Action on the user’s turn. For the rest of the turn, the user’s Normal-Type and Fighting-Type Moves can hit and affect Ghost-Type targets, and the user can see through the Illusion Ability, Moves with the Illusion keyword, and effects created by the Illusionist Capability, ignoring all effects from those.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Pain Split":{  
       "Type":"Normal",
@@ -4092,7 +4356,7 @@
       "Range":"4, 1 Target",
       "Effect":"The user and the target both lose 1/2 of their current Hit Points. Add the amount of Hit Points the user and the target lost together, and divide the value by 2. Both the target and the user gain Hit Points equal to this value. Do not add Injuries from Pain Split from Hit Point Markers until the full effect of the Move has been resolved. Pain Split never causes Massive Damage. Hit Point loss from Pain Split cannot be prevented in any way.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Pay Day":{  
       "Type":"Normal",
@@ -4103,7 +4367,8 @@
       "Range":"Cone 2",
       "Effect":"Pay Day scatters metal coins equal in value to 1d8 times the user's level. If it is a trainer battle, the winner of the battle gets to pick up the coins.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Perish Song":{  
       "Type":"Normal",
@@ -4112,7 +4377,7 @@
       "Range":"Burst 15, Sonic",
       "Effect":"Perish Song cannot miss. All targets, including the user, receive a Perish Count of 3. At the beginning of each of the target’s turns, their Perish count is lowered by 1. Once a Perish Count reaches 0, set the Pokémon’s Hit Points to 0. A Perish Count disappears if a target returns to their Poké Ball, Takes a Breather, or is knocked out. Perish Song never causes Massive Damage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Play Nice":{  
       "Type":"Normal",
@@ -4122,7 +4387,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Play Nice lowers the target’s Attack by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Pound":{  
       "Type":"Normal",
@@ -4132,7 +4397,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Present":{  
       "Type":"Normal",
@@ -4143,7 +4409,8 @@
       "Range":"4, 1 Target",
       "Effect":"Roll 1d6; Present has a DB equal to twice the result. On a result of 1, instead of taking damage the target gains 20 HP.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
+      "Crits On":20
    },
    "Protect":{  
       "Type":"Normal",
@@ -4152,7 +4419,7 @@
       "Range":"Self, Interrupt, Shield, Trigger",
       "Effect":"If the user is hit by a Move, the user may use Protect. The user is instead not hit by the Move. The user does not take any damage nor is affected by any of the Move's effects.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Psych Up":{  
       "Type":"Normal",
@@ -4161,7 +4428,7 @@
       "Range":"6, 1 Target",
       "Effect":"The user's Combat Stages are changed to match the target's Combat Stages. Psych Up cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Quick Attack":{  
       "Type":"Normal",
@@ -4171,7 +4438,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Priority",
       "Contest Type":"Cool",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Rage":{  
       "Type":"Normal",
@@ -4182,7 +4450,8 @@
       "Range":"Melee, 1 Target, Spirit Surge",
       "Effect":"The user becomes Enraged. Until the end of the user’s next turn, if the user is Enraged, the user gains +1 Attack Combat Stage whenever they are damaged by an Damaging Move or Attack.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
+      "Crits On":20
    },
    "Rapid Spin":{  
       "Type":"Normal",
@@ -4193,7 +4462,8 @@
       "Range":"Melee, 1 Target, Spirit Surge",
       "Effect":"Rapid Spin destroys all Hazards within 5 meters, removes Leech Seeds, and removes the user's Trapped or Stuck status.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Razor Wind":{  
       "Type":"Normal",
@@ -4204,7 +4474,8 @@
       "Range":"10, 3 Targets, Set -Up",
       "Effect":"Set-Up Effect: The user may not shift this round. The user whips up a whirlwind around themselves, granting +2 Evasion until the end of their next turn and destroying any Smokescreen or Hazards on any squares it is standing on and in all squares adjacent to it. Resolution Effect: The user attacks with Razor Wind. Razor Wind is a Critical Hit on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Recover":{  
       "Type":"Normal",
@@ -4213,7 +4484,7 @@
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP.",
       "Contest Type":"Smart",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Recycle":{  
       "Type":"Normal",
@@ -4222,7 +4493,7 @@
       "Range":"Self",
       "Effect":"The effect of a consumable item used earlier in the encounter is used again as if it had not been destroyed. The item is still gone.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Reflect Type":{  
       "Type":"Normal",
@@ -4232,7 +4503,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"Reflect Type changes one of the user’s Types into one Type of your choice that the target has for the rest of the scene.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Refresh":{  
       "Type":"Normal",
@@ -4241,7 +4512,7 @@
       "Range":"Self",
       "Effect":"The user is cured of all Poison, Burns, and Paralysis.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Relic Song":{  
       "Type":"Normal",
@@ -4252,7 +4523,8 @@
       "Range":"Burst 3, Friendly, Sonic",
       "Effect":"All legal targets fall Asleep on 16+. As long as Meloetta knows Relic Song, it may change between Aria Form and Step Form as a Swift Action when using Relic Song or as a Standard Action otherwise. Both Aria and Step Form must be statted with the same HP Stat.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
+      "Crits On":20
    },
    "Retaliate":{  
       "Type":"Normal",
@@ -4263,7 +4535,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Retaliate's DB is doubled to DB 14 (4d10+15 / 40) if an ally has been Fainted by a Damaging Move used by the Target in the last 2 rounds of Combat.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Return":{  
       "Type":"Normal",
@@ -4274,7 +4547,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Return's DB is equal to 3 plus the user's Loyalty Value.",
       "Contest Type":"Cute",
-      "Contest Effect":" Exhausting Act"
+      "Contest Effect":" Exhausting Act",
+      "Crits On":20
    },
    "Roar":{  
       "Type":"Normal",
@@ -4284,7 +4558,7 @@
       "Range":"Burst 1, Sonic, Social",
       "Effect":"When declaring Roar, the user does nothing. At the end of the round, the user Shifts and uses Roar. Targets hit by Roar immediately Shift away from the user using their highest useable movement capability, towards their Trainer if possible. If the target is an owned Pokémon and ends this shift within 6 meters of their Poké Ball, they are immediately recalled to their Poké Ball. If that Trainer sends out a replacement, they do not lose their Command action.",
       "Contest Type":"Cool",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Rock Climb":{  
       "Type":"Normal",
@@ -4295,7 +4569,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Rock Climb Confuses the target on 17+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Round":{  
       "Type":"Normal",
@@ -4306,7 +4581,8 @@
       "Range":"Burst 1, Sonic",
       "Effect":"Round's Damage Base is equal to 6, plus +2 more for each use of Round by any Trainer or Pokémon this round, up to a maximum of DB 12 (3d12+10 / 30).",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Safeguard":{  
       "Type":"Normal",
@@ -4315,7 +4591,7 @@
       "Range":"Blessing",
       "Effect":"Blessing – Any user affected by Safeguard may activate it when receiving a Status Affliction to ignore the effects of that Status Affliction on their next turn. Safeguard may be activated 3 times, and then disappears.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Scary Face":{  
       "Type":"Normal",
@@ -4325,7 +4601,7 @@
       "Range":"4, 1 Target, Social",
       "Effect":"Lower the target’s Speed by -2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
    },
    "Scratch":{  
       "Type":"Normal",
@@ -4335,7 +4611,8 @@
       "Class":"Physical",
       "Range":"Melee, Pass",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Screech":{  
       "Type":"Normal",
@@ -4345,7 +4622,7 @@
       "Range":"Burst 2, Friendly, Sonic",
       "Effect":"Lower the Defense of all legal targets by -2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Secret Power":{  
       "Type":"Normal",
@@ -4356,7 +4633,8 @@
       "Range":"4, 1 Target, Environ",
       "Effect":"Secret Power's effect depends on Environ. Secret Power's effect activates on 17+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
+      "Crits On":20
    },
    "Self-Destruct":{  
       "Type":"Normal",
@@ -4367,7 +4645,8 @@
       "Range":"Burst 3",
       "Effect":"The user's HP is set to -50% of its full HP. This HP loss may not be prevented or reduced in any way. The user's loyalty may be lowered.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
+      "Crits On":20
    },
    "Sharpen":{  
       "Type":"Normal",
@@ -4376,7 +4655,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack by +1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Shell Smash":{  
       "Type":"Normal",
@@ -4385,7 +4664,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Attack, Special Attack, and Speed by +2 CS each. Lower the user's Defense and Special Defense by -1 CS each.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Simple Beam":{  
       "Type":"Normal",
@@ -4395,7 +4674,7 @@
       "Range":"6, 1 Target",
       "Effect":"You choose one of the target's Abilities. Simple Beam changes that Ability to Simple for the remainder of the encounter.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
    },
    "Sing":{  
       "Type":"Normal",
@@ -4405,7 +4684,7 @@
       "Range":"Burst 2, Friendly, Sonic",
       "Effect":"All legal Targets fall Asleep. On a miss, Sing instead causes targets to become Slowed and suffer a -2 penalty to their Evasion until the end of the user's next turn.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Sketch":{  
       "Type":"Normal",
@@ -4414,7 +4693,7 @@
       "Range":"15, 1 Target",
       "Effect":"Sketch cannot miss. Once Sketch has been used, remove Sketch from the user's Move list. The last Move that the target used is added to the user's Move list permanently. Sketch may not be Interrupted or Intercepted.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
    },
    "Skull Bash":{  
       "Type":"Normal",
@@ -4425,7 +4704,8 @@
       "Range":"Melee, 1 Target, Dash, Push, Set-Up",
       "Effect":"Set-Up Effect: Raise the user's Defense by +1 CS. Resolution Effect: The user may attack with Skull Bash. The target is pushed 3 meters.",
       "Contest Type":"Tough",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Slack Off":{  
       "Type":"Normal",
@@ -4434,7 +4714,7 @@
       "Range":"Self",
       "Effect":"The user regains HP equal to half of its full HP.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Slam":{  
       "Type":"Normal",
@@ -4445,7 +4725,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Slam may be used as a Free Action at the end of a Sprint Maneuver taken as a Standard Action, as long as the user Shifted at least 3 meters in a straight line towards the target. When used this way, Slam gains the Smite keyword.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Slash":{  
       "Type":"Normal",
@@ -4456,7 +4737,8 @@
       "Range":"Melee, Pass",
       "Effect":"Slash is a Critical Hit on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":18
    },
    "Sleep Talk":{  
       "Type":"Normal",
@@ -4465,7 +4747,7 @@
       "Range":"Self",
       "Effect":"Select another of the user’s Moves at random; this turn, the user may Shift and use that Move despite being Asleep. Sleep Talk can be only be used by Sleeping targets.",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
    },
    "Smelling Salts":{  
       "Type":"Normal",
@@ -4476,7 +4758,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"If the target is Paralyzed, Smelling Salt’s Damage Base is doubled to 14 (4d10+15 / 40), and cures the target of Paralysis.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
+      "Crits On":20
    },
    "Smokescreen":{  
       "Type":"Normal",
@@ -4485,7 +4768,7 @@
       "Range":"5, Ranged Blast 3",
       "Effect":"Smokescreen creates a blast of Smoke that covers the target area; the Smoke persists until the end of the encounter, or until Defog or Whirlwind are used. All targets attacking from or into the Smoke receive a -3 penalty to Accuracy.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Snore":{  
       "Type":"Normal",
@@ -4496,7 +4779,8 @@
       "Range":"Burst 1, Sonic",
       "Effect":"Snore Flinches all legal targets on 15+. Snore may be used by Sleeping users.",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Soft-Boiled":{  
       "Type":"Normal",
@@ -4505,7 +4789,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target regains Hit Points equal to half of its full Hit Points. The user may target themselves with Soft-Boiled.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Sonic Boom":{  
       "Type":"Normal",
@@ -4516,7 +4800,8 @@
       "Range":"8, 1 Target",
       "Effect":"Sonicboom causes the target to lose 15 HP. Sonicboom is Special and interacts with other moves and effects as such (Special Evasion may be applied to avoid it, Mirror Coat can reflect it, etc.)",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Spike Cannon":{  
       "Type":"Normal",
@@ -4526,7 +4811,8 @@
       "Class":"Physical",
       "Range":"6, 1 Target, Five Strike",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Spit Up":{  
       "Type":"Normal",
@@ -4537,7 +4823,8 @@
       "Range":"4, 1 Target",
       "Effect":"For each Stockpiled Count the user has, Spit Up’s Damage Base is increased by +8. If the user has no Stockpiled count, Spit Up cannot be used.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Splash":{  
       "Type":"Normal",
@@ -4546,7 +4833,7 @@
       "Range":"Self",
       "Effect":"Shift Action - The user may make a single Jump, adding +1 to their Long Jump and High Jump values, and gains +2 Evasion until the end of their next turn. *Grants +1 Long Jump",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Stockpile":{  
       "Type":"Normal",
@@ -4555,7 +4842,7 @@
       "Range":"Self",
       "Effect":"The user adds 1 to their Stockpiled count to a maximum of 3. For each number a Stockpiled count is above 0, raise the user’s Defense and Special Defense by +1 CS each. If a Stockpiled count is set to 0, any Combat Stages gained from the Stockpiled count are removed.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Stomp":{  
       "Type":"Normal",
@@ -4566,7 +4853,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Stomp Flinches the target on 15+. If the target is at least one size category smaller than the user, Stomp deals an additional 10 damage.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Strength":{  
       "Type":"Normal",
@@ -4577,7 +4865,8 @@
       "Range":"Melee, 1 Target, Push",
       "Effect":"You may immediately initiate a Push Maneuver as a Free Action. The Maneuver automatically hits, but you must still make the Opposed Roll. *Grants +1 Power",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Substitute":{  
       "Type":"Normal",
@@ -4586,7 +4875,7 @@
       "Range":"Self, Illusion, Coat",
       "Effect":"The user loses 1/4 of their maximum Hit Points. This Hit Point loss cannot be prevented in any way. The user creates an Illusory Substitute Coat, which has Hit Points equal to 1/4th of the user’s full Hit Points +1. If the user would be hit by a Move or attack, instead the Substitute gets hit. Apply weakness, resistance and stats to the Substitute. The Substitute is immune to Status Afflictions and Status Moves. Moves with the Social or Sonic keywords completely ignore and bypass the Substitute. Once the Substitute has been destroyed, the user may be hit as normal. Substitute cannot be used if the user has less than 1/4 of their full Hit Points.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
    },
    "Super Fang":{  
       "Type":"Normal",
@@ -4597,7 +4886,8 @@
       "Range":"Melee, 1 Target",
       "Effect":" The target loses 1/2 of its current HP.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Supersonic":{  
       "Type":"Normal",
@@ -4607,7 +4897,7 @@
       "Range":"4, 1 Target, Sonic",
       "Effect":"The target becomes Confused. On miss, the target suffers a -2 penalty to Accuracy Rolls for one full round.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Swagger":{  
       "Type":"Normal",
@@ -4617,7 +4907,7 @@
       "Range":"6, 1 Target, Social",
       "Effect":"Raise the target's Attack by +2 CS. The target is Confused.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Swallow":{  
       "Type":"Normal",
@@ -4626,7 +4916,7 @@
       "Range":"Self",
       "Effect":"If the user’s Stockpiled count is 1, they are healed 25% of their full Hit Point value; if their Stockpiled count is 2, they are healed half of their full Hit Point value; if their Stockpiled count is 3, they are healed back to full Hit Points. After using Swallow, the user’s Stockpiled count is set to 0. If the user has no Stockpiled count, Swallow does nothing.",
       "Contest Type":"Tough",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Sweet Scent":{  
       "Type":"Normal",
@@ -4636,7 +4926,7 @@
       "Range":"Burst 2, Friendly",
       "Effect":"Targets hit by Sweet Scent gain a -2 Penalty to Evasion. (Total Evasion may not be lowered to a negative value.) *Grants Alluring",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Swift":{  
       "Type":"Normal",
@@ -4646,7 +4936,8 @@
       "Range":"8, Ranged Blast 2, Friendly",
       "Effect":"Swift cannot Miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Swords Dance":{  
       "Type":"Normal",
@@ -4655,7 +4946,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Attack by +2 CS.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Tackle":{  
       "Type":"Normal",
@@ -4666,7 +4957,8 @@
       "Range":"Melee, 1 Target, Dash, Push",
       "Effect":"The target is Pushed 2 Meters.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Tail Slap":{  
       "Type":"Normal",
@@ -4676,7 +4968,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Five Strike",
       "Contest Type":"Cute",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Tail Whip":{  
       "Type":"Normal",
@@ -4686,7 +4979,7 @@
       "Range":"Burst 1, Friendly",
       "Effect":"All legal targets have their Defense lowered by -1 CS.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Take Down":{  
       "Type":"Normal",
@@ -4697,7 +4990,8 @@
       "Range":"Melee, 1 Target, Dash, Recoil 1/3",
       "Effect":"You may perform a Trip Maneuver against the target as a Free Action.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Techno Blast":{  
       "Type":"Normal",
@@ -4708,7 +5002,8 @@
       "Range":"6, Ranged Blast 2",
       "Effect":"Techno Blast’s Type can be any Type while holding the appropriate Drive item or Plate item.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Teeter Dance":{  
       "Type":"Normal",
@@ -4718,7 +5013,7 @@
       "Range":"Burst 1",
       "Effect":"All legal targets are Confused.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Thrash":{  
       "Type":"Normal",
@@ -4729,7 +5024,8 @@
       "Range":"Melee, all adjacent foes, Smite",
       "Effect":"After damage is dealt, the user becomes Enraged and Confused.",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Tickle":{  
       "Type":"Normal",
@@ -4739,7 +5035,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"Lower the target’s Attack and Defense by -1 CS each.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Transform":{  
       "Type":"Normal",
@@ -4748,7 +5044,7 @@
       "Range":"10, 1 Target",
       "Effect":"The user targets a Pokémon within 10 meters and assumes the form of the target. It gains all of the target's Moves, Abilities, and Capabilities; and copies its weight and height. Transform lasts until the user is switched out, Fainted, or until the end of the encounter. The user may choose to end the Transformation on its turn as a free action, regaining its previous Move List. The user's Stats do not change from using Transform. Transform cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
    },
    "Tri Attack":{  
       "Type":"Normal",
@@ -4759,7 +5055,8 @@
       "Range":"6, 1 Target",
       "Effect":"Tri Attack gives the target a Status ailment on 17+. If this effect is triggered, roll 1d3; on 1 the target is Paralyzed; on 2 the target is Burned; on 3 the target is Frozen.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Trump Card":{  
       "Type":"Normal",
@@ -4770,7 +5067,8 @@
       "Range":"6, 1 Target",
       "Effect":"Whenever the user uses Trump Card, the user gains a Trump Count after the attack is resolved. Trump Card's DB is increased by +2 for each Trump Count.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Uproar":{  
       "Type":"Normal",
@@ -4781,7 +5079,8 @@
       "Range":"Burst 1, Spirit Surge, Sonic",
       "Effect":"All Pokémon and Trainers within 5 meters of the user are cured of Sleep.",
       "Contest Type":"Cute",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
+      "Crits On":20
    },
    "Vicegrip":{  
       "Type":"Normal",
@@ -4791,7 +5090,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Weather Ball":{  
       "Type":"Normal",
@@ -4802,7 +5102,8 @@
       "Range":"8, 1 Target",
       "Effect":"If it is Sunny, Weather Ball is Fire-Type. If it is Rainy, Weather Ball is Water-Type. If it is Hailing, Weather Ball is Ice-Type. If it is Sandstorming, Weather Ball is Rock-Type. When a weather effect is on the field, Weather Ball has a Damage Base of 10 (3d8+10 / 24). If there are multiple Weather Effects on the field, choose one type for Weather Ball to be that corresponds with an existing Weather Effect.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Whirlwind":{  
       "Type":"Normal",
@@ -4812,7 +5113,7 @@
       "Range":"Line 6",
       "Effect":"All targets are pushed X meters, where X is 8 minus their weight class. If the Line targets into a Smokescreen, the smoke is dispersed. All hazards in the Whirlwind are destroyed.",
       "Contest Type":"Smart",
-      "Contest Effect":"Big Show"
+      "Contest Effect":"Big Show",
    },
    "Wish":{  
       "Type":"Normal",
@@ -4821,7 +5122,7 @@
       "Range":"15, 1 Target",
       "Effect":"At the end of the user's next turn, the target regains HP equal to half of its full HP. If the user targets itself and is replaced in battle, the replacement is healed by half of its own HP.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Work Up":{  
       "Type":"Normal",
@@ -4830,7 +5131,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Special Attack by +1 CS each.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Wrap":{  
       "Type":"Normal",
@@ -4839,7 +5140,8 @@
       "Range":"--",
       "Effect":"The user gains a +1 Bonus to Accuracy Rolls made to initiate Grapple Maneuvers, and +2 to Skill Checks made to initiate Grapple Maneuvers or gain Dominance. Whenever the user gains Dominance in a Grapple, the target of the Grapple loses a Tick of Hit Points.",
       "Contest Type":"Tough",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Wring Out":{  
       "Type":"Normal",
@@ -4850,7 +5152,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"For every 10% the target is below their full HP, Wring Out's Damage Base is reduced by -1.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Yawn":{  
       "Type":"Normal",
@@ -4859,7 +5162,7 @@
       "Range":"2, 1 Target, Social",
       "Effect":"The target falls Asleep at the end of its next turn. Yawn cannot miss.",
       "Contest Type":"Cute",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Acid":{  
       "Type":"Poison",
@@ -4870,7 +5173,8 @@
       "Range":"Cone 2",
       "Effect":"Acid lowers the target’s Defense by -1 Combat Stage on 18+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Acid Armor":{  
       "Type":"Poison",
@@ -4879,7 +5183,7 @@
       "Range":"Self, Set-Up",
       "Effect":"Set-Up Effect: The user becomes Liquefied. While Liquefied, the user is Slowed and cannot take Standard Actions except to Resolve the effect of Acid Armor, the user's Movement is never obstructed by rough or slow terrain, and the user can shift even through the smallest openings. Furthermore, while Liquefied, the user is completely immune to all Physical damage and becomes completely invisible if fully submerged in any liquid. Resolution Effect: The user gains +1 Defense CS, then stops being liquified.",
       "Contest Type":"Tough",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Acid Spray":{  
       "Type":"Poison",
@@ -4890,7 +5194,8 @@
       "Range":"4, 1 Target",
       "Effect":"Acid Spray lowers the target’s Special Defense by -2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
+      "Crits On":20
    },
    "Belch":{  
       "Type":"Poison",
@@ -4901,7 +5206,8 @@
       "Range":"Cone 2",
       "Effect":"Belch cannot be used if the user has not traded in a Digestion/Food Buff during this Scene.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Clear Smog":{  
       "Type":"Poison",
@@ -4911,7 +5217,8 @@
       "Range":"6, 1 Target",
       "Effect":"The target's Combat Stages are reset to their defaults, and all Coats on the target are destroyed. Clear Smog cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
+      "Crits On":20
    },
    "Coil":{  
       "Type":"Poison",
@@ -4920,7 +5227,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack and Defense by +1 CS, and the user gains +1 Accuracy.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Cross Poison":{  
       "Type":"Poison",
@@ -4931,7 +5238,8 @@
       "Range":"Melee, Pass",
       "Effect":"Cross Poison is a Critical Hit on 18+ and Poisons the target on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":18
    },
    "Gastro Acid":{  
       "Type":"Poison",
@@ -4941,7 +5249,7 @@
       "Range":"4. 1 Target",
       "Effect":"The target's Ability is disabled until the end of the encounter. If the target has more than one ability, you choose one of them to disable.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Gunk Shot":{  
       "Type":"Poison",
@@ -4952,7 +5260,8 @@
       "Range":"6, 1 Target, Smite",
       "Effect":"Gunk Shot Poisons the target on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Poison Fang":{  
       "Type":"Poison",
@@ -4963,7 +5272,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Poison Fang Badly Poisons the target on 17+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Poison Gas":{  
       "Type":"Poison",
@@ -4973,7 +5283,7 @@
       "Range":"Burst 1 or Cone 2",
       "Effect":"Poison Gas Poisons all legal targets.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
    },
    "Poison Jab":{  
       "Type":"Poison",
@@ -4984,7 +5294,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Poison Jab Poisons the target on 15+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Poison Powder":{  
       "Type":"Poison",
@@ -4994,7 +5305,7 @@
       "Range":"4, 1 Target, Powder",
       "Effect":"The target is Poisoned.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Poison Sting":{  
       "Type":"Poison",
@@ -5005,7 +5316,8 @@
       "Range":"6, 1 Target",
       "Effect":"Poison Sting Poisons the target on 17+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
+      "Crits On":20
    },
    "Poison Tail":{  
       "Type":"Poison",
@@ -5016,7 +5328,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Poison Tail is a Critical Hit on 18+ and Poisons the target on 19+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":18
    },
    "Sludge":{  
       "Type":"Poison",
@@ -5027,7 +5340,8 @@
       "Range":"6, 1 Target",
       "Effect":"Sludge Poisons the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Sludge Bomb":{  
       "Type":"Poison",
@@ -5038,7 +5352,8 @@
       "Range":"8, 1 Target",
       "Effect":"Sludge Bomb Poisons the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Sludge Wave":{  
       "Type":"Poison",
@@ -5049,7 +5364,8 @@
       "Range":"Burst 1 or Close Blast 2",
       "Effect":"Sludge Wave Poisons all legal targets on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Smog":{  
       "Type":"Poison",
@@ -5060,7 +5376,8 @@
       "Range":"Line 2",
       "Effect":"Smog Poisons all legal targets on an Even-Numbered Roll.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Toxic":{  
       "Type":"Poison",
@@ -5070,7 +5387,7 @@
       "Range":"4, 1 Target",
       "Effect":"The target is Badly Poisoned. If the user is Poison Type, Toxic cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Toxic Spikes":{  
       "Type":"Poison",
@@ -5079,7 +5396,7 @@
       "Range":"6, Hazard",
       "Effect":"Set 8 square meters of Toxic Spikes within the range such that all 8 meters are adjacent with at least one other space of Toxic Spikes. Toxic Spikes cause Terrain to become Slow Terrain, and a grounded foe that runs into the hazard becomes Poisoned and Slowed until the end of their next turn. If there are 2 layers of Toxic Spikes on the same space, it Badly Poisons the foes instead. Poison-Type Pokémon may move over Toxic Spikes harmlessly, destroying the Hazards as they do so.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Venom Drench":{  
       "Type":"Poison",
@@ -5088,7 +5405,7 @@
       "Range":"Cone 2",
       "Effect":"All Poisoned targets have their Attack, Special Attack, and Speed lowered by -1 CS. Venom Drench cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Venoshock":{  
       "Type":"Poison",
@@ -5099,7 +5416,8 @@
       "Range":"6, 1 Target",
       "Effect":"If the target is Poisoned, Venoshock has a Damage Base of 13 (4d10+10 / 35) instead.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Agility":{  
       "Type":"Psychic",
@@ -5108,7 +5426,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Speed 2 Combat Stages.",
       "Contest Type":"Cool",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
    },
    "Ally Switch":{  
       "Type":"Psychic",
@@ -5117,7 +5435,7 @@
       "Range":"6, 1 Target, Interrupt",
       "Effect":"Ally Switch may be declared during a foe’s turn as an Interrupt. The user chooses one willing ally within 6 meters; the target and the user switch places. If the ally was a target of a Move, the user is now the target; If the user was a target of a Move, the ally is now the target.",
       "Contest Type":"Cool",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Amnesia":{  
       "Type":"Psychic",
@@ -5126,7 +5444,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Special Defense 2 Combat Stages.",
       "Contest Type":"Cute",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Barrier":{  
       "Type":"Psychic",
@@ -5135,7 +5453,7 @@
       "Range":"Hazard",
       "Effect":"The user creates a Barrier of psychic energy. The user places up to 4 segments of Barrier; each segment must be continuous with another segment, and at least one must be adjacent to the user. These barriers count as blocking terrain and last until the end of the encounter or until they are destroyed. Each Barrier segment is 2 meters tall, 1 meter wide, and 2 centimeters thick. Each segment has 20 Hit Points, 15 Damage Reduction, and takes damage as if it was Psychic Typed.",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Calm Mind":{  
       "Type":"Psychic",
@@ -5144,7 +5462,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Special Attack 1 Combat Stage and raise the user’s Special Defense 1 Combat Stage.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Confusion":{  
       "Type":"Psychic",
@@ -5155,7 +5473,8 @@
       "Range":"6, 1 Target",
       "Effect":"Confusion Confuses the target on 19+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Cosmic Power":{  
       "Type":"Psychic",
@@ -5164,7 +5483,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Defense 1 Combat Stage and raise the user’s Special Defense 1 Combat Stage.",
       "Contest Type":"Cool",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Dream Eater":{  
       "Type":"Psychic",
@@ -5175,7 +5494,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Dream Eater can only target Sleeping Pokémon or Trainers. After the target takes damage, the user gains Hit Points equal to half of the damage they dealt to the target. Dream Eater does not wake up sleeping targets.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
+      "Crits On":20
    },
    "Extrasensory":{  
       "Type":"Psychic",
@@ -5186,7 +5506,8 @@
       "Range":"5, 1 Target",
       "Effect":"Extrasensory Flinches the target on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Future Sight":{  
       "Type":"Psychic",
@@ -5196,7 +5517,8 @@
       "Range":"10, 1 Target",
       "Effect":"Future Sight does nothing on the turn it is used. At the end of the user's next turn, Future Sight hits, even if the user is no longer on the field. Future Sight cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Gravity":{  
       "Type":"Psychic",
@@ -5205,7 +5527,7 @@
       "Range":"Field",
       "Effect":"For 5 rounds, the area is considered Warped. While Warped, Moves that involve the user being airborne may not be used. Pokémon cannot use Sky or Levitate Capabilities to end their turn at an altitude higher than 1 meter. Flying-Types and Pokémon with the Ability Levitate are no longer immune to Ground-Type Moves. All Accuracy Rolls receive a +2 Bonus.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Guard Split":{  
       "Type":"Psychic",
@@ -5214,7 +5536,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target loses 5 Defense and 5 Special Defense. If they do, the user gains 5 Damage Reduction. These effects last until the end of the Scene.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Guard Swap":{  
       "Type":"Psychic",
@@ -5223,7 +5545,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user and the target trade Combat Stage values for the Defense Stat, and then for the Special Defense Stat.",
       "Contest Type":"Cute",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Heal Block":{  
       "Type":"Psychic",
@@ -5233,7 +5555,7 @@
       "Range":"6, 1 Target",
       "Effect":"Until the end of the encounter, the target may not gain HP or Temporary HP from any source. This effect ends if the target is switched out or Takes a Breather.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Healing Wish":{  
       "Type":"Psychic",
@@ -5242,7 +5564,7 @@
       "Range":"6, 1 Target",
       "Effect":"The user immediately Faints, lowering its HP to 0. The user takes no Injuries from HP Markers when using Healing Wish. The target is immediately cured of up to 3 injuries, healed to their Maximum Hit Points, and has the Frequency of all Moves restored. Healing Wish may target a Pokémon in a Poké Ball. Healing Wish does not restore the Frequency of Healing Wish or Lunar Dance. Injuries healed through Healing Wish count toward the total number of Injuries that can be healed each day, and this healing is limited by the same.",
       "Contest Type":"Cute",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Heal Pulse":{  
       "Type":"Psychic",
@@ -5251,7 +5573,7 @@
       "Range":"6, 1 Target, Aura",
       "Effect":"Restores 50% of the target’s max Hit Points. Heal Pulse’s user may not target itself with Heal Pulse.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Heart Stamp":{  
       "Type":"Psychic",
@@ -5262,7 +5584,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Heart Stamp Flinches the target on 15+.",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Heart Swap":{  
       "Type":"Psychic",
@@ -5271,7 +5594,7 @@
       "Range":"10, 2 Targets",
       "Effect":"The targets trade Combat Stage values for each stat.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Hypnosis":{  
       "Type":"Psychic",
@@ -5281,7 +5604,7 @@
       "Range":"4, 1 Target",
       "Effect":"The target falls Asleep.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Imprison":{  
       "Type":"Psychic",
@@ -5290,7 +5613,7 @@
       "Range":"10, 1 Target",
       "Effect":"The target is Locked for the rest of the Scene. A Locked target may not use any Moves the user knows. Imprison cannot miss.",
       "Contest Type":"Smart",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Kinesis":{  
       "Type":"Psychic",
@@ -5299,7 +5622,7 @@
       "Range":"6, 1 Target, Trigger, Interrupt",
       "Effect":"If the user or an Ally within 6 meters is about to be hit by an attack, the user may use Kinesis as an interrupt. The triggering Accuracy Roll receives a -4 penalty. This may cause Moves to miss.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Light Screen":{  
       "Type":"Psychic",
@@ -5308,7 +5631,7 @@
       "Range":"Blessing",
       "Effect":"Blessing – Any user affected by Light Screen may activate it when receiving Special Damage to resist the Damage one step. Light Screen may be activated 2 times, and then disappears.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Lunar Dance":{  
       "Type":"Psychic",
@@ -5317,7 +5640,7 @@
       "Range":8,
       "Effect":"The user immediately Faints, lowering its Hit Points to 0. The user takes no Injuries from Hit Point Markers when using Lunar Dance. The target is immediately cured of up to 3 injuries, healed to their Maximum Hit Points, and has the Frequency of all Moves restored. Lunar Dance may target a Pokémon in a Poké Ball. Lunar Dance does not restore the Frequency of Healing Wish or Lunar Dance. Injuries healed through Lunar Dance count toward the total number of Injuries that can be healed each day, and this healing is limited by the same.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Luster Purge":{  
       "Type":"Psychic",
@@ -5328,7 +5651,8 @@
       "Range":"8, 1 Target",
       "Effect":"Luster Purge lowers the target's Special Defense by -1 CS on an Even-Numbered Roll.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Magic Coat":{  
       "Type":"Psychic",
@@ -5337,7 +5661,7 @@
       "Range":"4, Interrupt, Trigger",
       "Effect":"If the user is about to get a hit by a Move that does not have a Damage Dice Roll, they may use Magic Coat as an Interrupt. The Interrupted Move’s user is treated as if they were the target of their own Move, with the user of Magic Coat as the user.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
    },
    "Magic Room":{  
       "Type":"Psychic",
@@ -5346,7 +5670,7 @@
       "Range":"Field",
       "Effect":"The area becomes Useless for 5 rounds. While Useless, Pokémon may not benefit from the effects of any Held Items, and Trainers cannot benefit from any Accessory-Slot equipment. This does not affect consumable or activated items, only Items with Static effects or Triggers.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Meditate":{  
       "Type":"Psychic",
@@ -5355,7 +5679,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack 1 Combat Stage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Miracle Eye":{  
       "Type":"Psychic",
@@ -5364,7 +5688,7 @@
       "Range":"Self, Swift Action",
       "Effect":"Miracle Eye may be activated as a Swift Action on the user’s turn. For the rest of the turn, the user’s Psychic-Type Moves can hit and affect Dark-Type targets, and the user can see through the Illusion Ability, Moves with the Illusion keyword, and effects created by the Illusionist Capability, ignoring all effects from those.",
       "Contest Type":"Cute",
-      "Contest Effect":" Good Show!"
+      "Contest Effect":" Good Show!",
    },
    "Mirror Coat":{  
       "Type":"Psychic",
@@ -5373,7 +5697,7 @@
       "Range":"Any, 1 Target, Reaction",
       "Effect":"Mirror Coat may be used as a Reaction when the user is hit by a damaging Special Attack. Resolve the Triggering Attack, with Mirror Coat’s user resisting the attack one step further. After the attack is resolved, if Mirror Coat’s user was not Fainted, the triggering foe then loses Hit Points equal to twice the amount of Hit Points lost by the user from the triggering attack. Note that Mirror Coat is Special, and while it cannot miss, it cannot hit targets immune to Psychic-Type Moves.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
    },
    "Mist Ball":{  
       "Type":"Psychic",
@@ -5384,7 +5708,8 @@
       "Range":"12, 1 Target",
       "Effect":"Mist Ball lowers the target’s Special Attack by 1 Combat Stage on an Even-Numbered Roll.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Power Split":{  
       "Type":"Psychic",
@@ -5393,7 +5718,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The target has their Attack and Special Attack lowered by 5. If they do, the user gains a +5 bonus to Damage Rolls. These effects last until the end of the scene.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Power Swap":{  
       "Type":"Psychic",
@@ -5402,7 +5727,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user and the target trade Combat Stage values for the Attack Stat, and then for the Special Attack Stat.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Power Trick":{  
       "Type":"Psychic",
@@ -5411,7 +5736,7 @@
       "Range":"Self",
       "Effect":"The user's Attack stat and Defense stat are switched for the remainder of the encounter, or until the user is switched out or Fainted.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Psybeam":{  
       "Type":"Psychic",
@@ -5422,7 +5747,8 @@
       "Range":"6, 1 Target",
       "Effect":"Psybeam Confuses the target on 19+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Psychic":{  
       "Type":"Psychic",
@@ -5433,7 +5759,8 @@
       "Range":"5, 1 Target, Push",
       "Effect":"The target is Pushed 1 meter in any direction. Psychic lowers the target’s Special Defense 1 Combat Stage on 17+.  Grants Telekinetic.",
       "Contest Type":"Smart",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Psycho Boost":{  
       "Type":"Psychic",
@@ -5444,7 +5771,8 @@
       "Range":"8, Ranged Blast 3, Smite",
       "Effect":"Lower the user's Special Attack by -2 Combat Stages after damage is resolved.",
       "Contest Type":"Smart",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Psycho Cut":{  
       "Type":"Psychic",
@@ -5455,7 +5783,8 @@
       "Range":"6, 1 Target",
       "Effect":"Psycho Cut is a Critical Hit on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":18
    },
    "Psycho Shift":{  
       "Type":"Psychic",
@@ -5464,7 +5793,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user is cured of a Status ailment and the target is given that Status ailment. Psycho Shift cannot miss. Psycho Shift can only be used if the user has a Status ailment and the target does not have the status ailment that is being transferred.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Psyshock":{  
       "Type":"Psychic",
@@ -5475,7 +5804,8 @@
       "Range":"4, 1 Target",
       "Effect":"When calculating damage, the target subtracts their Defense from Psyshock's damage instead of their Special Defense. Psyshock is still otherwise Special (Special Evasion is used to avoid it, Mirror Coat can reflect it, etc.)",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Psystrike":{  
       "Type":"Psychic",
@@ -5486,7 +5816,8 @@
       "Range":"4, 1 Target",
       "Effect":" When calculating damage, the target subtracts their Defense from Psystrike's damage instead of their Special Defense. Psystrike is still otherwise Special (Special Evasion is used to avoid it, Mirror Coat can reflect it, etc.)",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Psywave":{  
       "Type":"Psychic",
@@ -5497,7 +5828,8 @@
       "Range":"6, 1 Target",
       "Effect":"Roll 1d4; on 1 the target loses HP equal to half the user's Level; on 2 the target loses HP equal to the user's Level; on 3 the target loses HP equal to 1.5x the user's level; on 4 the target loses HP equal to the user's Level doubled. Do not apply weakness or resistance, and do not apply Stats. Do apply Immunity.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Reflect":{  
       "Type":"Psychic",
@@ -5506,7 +5838,7 @@
       "Range":"Blessing",
       "Effect":"Blessing – Any user affected by Reflect may activate it when receiving Physical Damage to resist the Damage one step. Reflect may be activated 2 times, and then disappears.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Rest":{  
       "Type":"Psychic",
@@ -5515,7 +5847,7 @@
       "Range":"Self",
       "Effect":"The user is set to their full Hit Point value. The user is cured of any Status ailments. Then, the user falls Asleep. The user cannot make Sleep Checks at the beginning of their turn. They are cured of the Sleep at the end of their turn in 2 rounds.",
       "Contest Type":"Cute",
-      "Contest Effect":"Reflective Appeal"
+      "Contest Effect":"Reflective Appeal",
    },
    "Role Play":{  
       "Type":"Psychic",
@@ -5524,7 +5856,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user gains one of the target's Abilities, chosen at random, for the remainder of the encounter. This effect ends if the user Faints or is switched out. Role Play cannot miss.",
       "Contest Type":"Cute",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
    },
    "Skill Swap":{  
       "Type":"Psychic",
@@ -5533,7 +5865,7 @@
       "Range":"Melee, 1 Target",
       "Effect":"The user loses one of their Abilities, selected by the user, and gains one the target’s Abilities, selected at random, for the remainder of encounter. The target loses the copied Ability, and gains the user’s lost Ability. This effect ends if either the target or the user is Switched out or Fainted, but only for that Pokémon or Trainer.",
       "Contest Type":"Smart",
-      "Contest Effect":"Excitement"
+      "Contest Effect":"Excitement",
    },
    "Stored Power":{  
       "Type":"Psychic",
@@ -5544,7 +5876,8 @@
       "Range":"10, 1 Target",
       "Effect":"For every Combat Stage the user has above 0, add +2 to Stored Power’s Damage Base, up to a maximum of Damage Base 20.",
       "Contest Type":"Tough",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Synchronoise":{  
       "Type":"Psychic",
@@ -5555,7 +5888,8 @@
       "Range":"Burst 3",
       "Effect":"Synchronoise can only hit targets that share a type with Synchronoise's user.",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Telekinesis":{  
       "Type":"Psychic",
@@ -5564,7 +5898,7 @@
       "Range":"4, 1 Target",
       "Effect":"The target becomes Lifted. While Lifted, they gain the Levitate Ability, are Slowed, and lose all Movement Capabilities except for the Levitate 4 granted by Levitate (reduced to 2 by the Slow condition). While Lifted, the user may not apply any Evasion bonuses to determine whether they are hit by Moves or not. The Lifted target may use a Shift Action to roll 1d20; on a result of 16+, they stop being Lifted. *Grants Telekinetic",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
    },
    "Teleport":{  
       "Type":"Psychic",
@@ -5573,7 +5907,7 @@
       "Range":"Self, Interrupt",
       "Effect":"The user Teleports up to X meters, where X is its Teleporter Capability. Any Move that targeted Teleport's user continue through the desired target's space if the Move allows for it as if the user hadn't been there; single target moves simply miss. *Grants Teleporter 4",
       "Contest Type":"Cool",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
    },
    "Trick":{  
       "Type":"Psychic",
@@ -5583,7 +5917,7 @@
       "Range":"5, 2 Targets",
       "Effect":"Both targets must be hit for Trick to succeed. The user may target itself or willing allies with Trick; you do not need to roll for Accuracy Check in these cases. Both targets lose their Held Item and gain the other target's Held Item. If a target has no Held Item, they still can gain the other target's Held Item.",
       "Contest Type":"Smart",
-      "Contest Effect":"Attention Grabber"
+      "Contest Effect":"Attention Grabber",
    },
    "Trick Room":{  
       "Type":"Psychic",
@@ -5592,7 +5926,7 @@
       "Range":"Field",
       "Effect":"Starting at the beginning of the next round, for 5 rounds, the area is considered Rewinding. While Rewinding, Initiative is reversed, and participants instead go from lowest Initiative to highest.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Wonder Room":{  
       "Type":"Psychic",
@@ -5601,7 +5935,7 @@
       "Range":"Field",
       "Effect":"For 5 rounds, the area is considered Wondered. While Wondered, each individual Pokémon's Defense and Special Defense are switched.",
       "Contest Type":"Cute",
-      "Contest Effect":"Tease"
+      "Contest Effect":"Tease",
    },
    "Zen Headbutt":{  
       "Type":"Psychic",
@@ -5612,7 +5946,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Zen Headbutt Flinches the target on 15+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Ancient Power":{  
       "Type":"Rock",
@@ -5623,7 +5958,8 @@
       "Range":"6, 1 Target, Spirit Surge",
       "Effect":"The user has each of its stats raised by +1 CS on 19+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Diamond Storm":{  
       "Type":"Rock",
@@ -5634,7 +5970,8 @@
       "Range":"Close Blast 3, Friendly, Smite",
       "Effect":"Diamond Storm raises the User’s Defense by +1 CS on an Even-Numbered Roll.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Head Smash":{  
       "Type":"Rock",
@@ -5645,7 +5982,8 @@
       "Range":"Melee, 1 Target, Dash, Push, Recoil 1/3",
       "Effect":"The target is pushed 2 meters.",
       "Contest Type":"Tough",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Power Gem":{  
       "Type":"Rock",
@@ -5655,7 +5993,8 @@
       "Class":"Special",
       "Range":"6, 1 Target",
       "Contest Type":"Beauty",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Rock Blast":{  
       "Type":"Rock",
@@ -5666,7 +6005,8 @@
       "Range":"6, 1 Target, Five Strike",
       "Effect":"*Grants Materializer",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Rock Polish":{  
       "Type":"Rock",
@@ -5675,7 +6015,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Speed by +2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
    },
    "Rock Slide":{  
       "Type":"Rock",
@@ -5686,7 +6026,8 @@
       "Range":"6, Ranged Blast 3",
       "Effect":"Rock Slide Flinches all legal targets on 17+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Rock Throw":{  
       "Type":"Rock",
@@ -5696,7 +6037,8 @@
       "Class":"Physical",
       "Range":"6, 1 Target",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Rock Tomb":{  
       "Type":"Rock",
@@ -5707,7 +6049,8 @@
       "Range":"6, 1 Target",
       "Effect":"Rock Tomb lowers the target's Speed by -1 CS. *Grants Materializer",
       "Contest Type":"Smart",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Rock Wrecker":{  
       "Type":"Rock",
@@ -5718,7 +6061,8 @@
       "Range":"Melee, 1 Target, Dash, Exhaust, Smite",
       "Effect":"*Grants Materializer",
       "Contest Type":"Tough",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Rollout":{  
       "Type":"Rock",
@@ -5729,7 +6073,8 @@
       "Range":"Melee, Pass",
       "Effect":"The user continues to use Rollout on each of its turns until they miss any target with Rollout, or are not able to hit any target with Rollout during their turn. Each successive use of Rollout increases Rollout’s Damage Base by +4 to a maximum of DB 15.",
       "Contest Type":"Tough",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Sandstorm":{  
       "Type":"Rock",
@@ -5738,7 +6083,7 @@
       "Range":"Field, Weather",
       "Effect":"The weather changes to a Sandstorm for 5 rounds. While it is Sandstorming, all non-Ground, Rock, or Steel Type Pokémon lose a Tick of Hit Points at the beginning of their turn.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Smack Down":{  
       "Type":"Rock",
@@ -5749,7 +6094,8 @@
       "Range":"8, 1 Target",
       "Effect":"The target is knocked down to ground level, and loses all Sky or Levitate Speeds for 3 turns. During this time, they may be hit by Ground-Type Moves even if normally immune.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Stealth Rock":{  
       "Type":"Rock",
@@ -5758,7 +6104,7 @@
       "Range":"Field, Hazard",
       "Effect":"Set 4 square meters of Stealth Rock hazards within 6 meters. If a foe moves within 2 meters of a space occupied by Rocks, move at most one Rock to the offender, then destroy the Rock. When that happens, the Stealth Rock causes a foe to lose a Tick of Hit Points. Stealth Rock is considered to be dealing damage; Apply Weakness and Resistance. Do not apply stats. A Pokémon who has been hit by a Stealth Rock Hazard cannot get hit by another in the same encounter until it is returned to a Poké Ball and then sent back out. *Grants Materializer",
       "Contest Type":"Cool",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Stone Edge":{  
       "Type":"Rock",
@@ -5769,7 +6115,8 @@
       "Range":"8, 1 Target",
       "Effect":"Stone Edge is a Critical Hit on 17+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":17
    },
    "Wide Guard":{  
       "Type":"Rock",
@@ -5778,7 +6125,7 @@
       "Range":"Burst 1, Interrupt, Shield, Trigger",
       "Effect":"If an Ally adjacent to Wide Guard’s user is hit by a Move, you may use Wide Guard as an Interrupt. All targets adjacent to Wide Guard’s user, including the user, are instead not hit by the triggering Move and do not suffer any of its effects.",
       "Contest Type":"Tough",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Autotomize":{  
       "Type":"Steel",
@@ -5787,7 +6134,7 @@
       "Range":"Self",
       "Effect":"For the remainder of the Encounter, the user’s Weight Class is one value lower, to a minimum of 1. If the user can, the user’s Speed is raised by +2 Combat Stages.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Bullet Punch":{  
       "Type":"Steel",
@@ -5797,7 +6144,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Priority",
       "Contest Type":"Smart",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Doom Desire":{  
       "Type":"Steel",
@@ -5807,7 +6155,8 @@
       "Range":"10, 1 Target",
       "Effect":"Doom Desire does nothing on the turn it is used. At the end of the user's next turn, Doom Desire hits, even if the user if no longer on the field. Doom Desire cannot miss.",
       "Contest Type":"Cool",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Flash Cannon":{  
       "Type":"Steel",
@@ -5818,7 +6167,8 @@
       "Range":"6, 1 Target",
       "Effect":"Flash Cannon lowers the target's Special Defense by -1 CS on 17+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Gear Grind":{  
       "Type":"Steel",
@@ -5828,7 +6178,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Double Strike",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Gyro Ball":{  
       "Type":"Steel",
@@ -5839,7 +6190,8 @@
       "Range":"6, 1 Target",
       "Effect":"The target reveals their Speed Stat (including Combat Stages). If it is higher than the user’s (including Combat Stages), subtract the user’s Speed Stat from the target’s and apply the difference as Bonus Damage.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
+      "Crits On":20
    },
    "Heavy Slam":{  
       "Type":"Steel",
@@ -5850,7 +6202,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"For each weight class the user is above the target, increase Heavy Slam's Damage Base by +2.",
       "Contest Type":"Tough",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Iron Defense":{  
       "Type":"Steel",
@@ -5859,7 +6212,7 @@
       "Range":"Self",
       "Effect":"Raise the user's Defense by +2 CS.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Iron Head":{  
       "Type":"Steel",
@@ -5870,7 +6223,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Iron Head Flinches the target on 15+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Iron Tail":{  
       "Type":"Steel",
@@ -5881,7 +6235,8 @@
       "Range":"Melee, 1 Target, Smite",
       "Effect":"Iron Tail lowers the target’s Defense by -1 CS on 19+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "King's Shield":{  
       "Type":"Steel",
@@ -5890,7 +6245,7 @@
       "Range":" Self, Interrupt, Shield, Trigger",
       "Effect":" If the user is hit by an attack, the user may use King’s Shield. The user is instead not hit by the Move. You do not take any damage nor are you affected by any of the Move’s effects. In addition, if the triggering attack was Melee ranged, the attacker’s Attack is lowered by -2 CS.",
       "Contest Type":"Cool",
-      "Contest Effect":"Inversed Appeal"
+      "Contest Effect":"Inversed Appeal",
    },
    "Magnet Bomb":{  
       "Type":"Steel",
@@ -5900,7 +6255,8 @@
       "Range":"8, 1 Target",
       "Effect":"Magnet Bomb cannot miss. *Grants Magnetic",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Metal Burst":{  
       "Type":"Steel",
@@ -5910,7 +6266,8 @@
       "Range":"Burst 1",
       "Effect":"Metal Burst causes all legal targets in the burst to lose HP equal to the total amount of direct Damage the user has taken since the beginning of this Round. Metal Burst cannot miss.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Double Time"
+      "Contest Effect":"Double Time",
+      "Crits On":20
    },
    "Metal Claw":{  
       "Type":"Steel",
@@ -5921,7 +6278,8 @@
       "Range":"Melee, 1 Target, Spirit Surge",
       "Effect":"Raise the user's Attack by +1 CS on 18+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Metal Sound":{  
       "Type":"Steel",
@@ -5931,7 +6289,7 @@
       "Range":"Burst 2, Friendly, Sonic",
       "Effect":"All Legal Targets have their Special Defense lowered by -2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Unsettling"
+      "Contest Effect":"Unsettling",
    },
    "Meteor Mash":{  
       "Type":"Steel",
@@ -5942,7 +6300,8 @@
       "Range":"Melee, 1 Target, Dash, Spirit Surge",
       "Effect":"Raise the user's Attack by +1 CS on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Mirror Shot":{  
       "Type":"Steel",
@@ -5953,7 +6312,8 @@
       "Range":"6, Ranged Blast 2",
       "Effect":"All Legal Targets have their Accuracy lowered by -2 on 16+.",
       "Contest Type":"Cute",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Shift Gear":{  
       "Type":"Steel",
@@ -5962,7 +6322,7 @@
       "Range":"Self",
       "Effect":"Raise the user’s Attack by +1 CS and Speed by +2 CS.",
       "Contest Type":"Smart",
-      "Contest Effect":"Get Ready!"
+      "Contest Effect":"Get Ready!",
    },
    "Steel Wing":{  
       "Type":"Steel",
@@ -5973,7 +6333,8 @@
       "Range":"Melee, Pass, Spirit Surge",
       "Effect":"Steel Wing raises the user's Defense by +1 CS on 15+.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Aqua Jet":{  
       "Type":"Water",
@@ -5983,7 +6344,8 @@
       "Class":"Physical",
       "Range":"Melee, 1 Target, Priority",
       "Contest Type":"Beauty",
-      "Contest Effect":"Saving Grace"
+      "Contest Effect":"Saving Grace",
+      "Crits On":20
    },
    "Aqua Ring":{  
       "Type":"Water",
@@ -5992,7 +6354,7 @@
       "Range":"Self, Coat",
       "Effect":"Aqua Ring covers the user in a Coat that heals the user at the beginning of their turn. The user is healed a Tick of Hit Points each turn.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Aqua Tail":{  
       "Type":"Water",
@@ -6002,7 +6364,8 @@
       "Class":"Physical",
       "Range":"Melee, Pass",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Brine":{  
       "Type":"Water",
@@ -6013,7 +6376,8 @@
       "Range":"6,  1 Target",
       "Effect":"If the target’s Hit Points are under 50%, Brine’s Damage Base is increased to Damage Base 13 (4d10+10 / 35).",
       "Contest Type":"Smart",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Bubble":{  
       "Type":"Water",
@@ -6024,7 +6388,8 @@
       "Range":"Burst 1",
       "Effect":"Bubble lowers the target's Speed by -1 CS on 16+..",
       "Contest Type":"Cute",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Bubblebeam":{  
       "Type":"Water",
@@ -6035,7 +6400,8 @@
       "Range":"4, 1 Target",
       "Effect":"Bubblebeam lowers the target's Speed by -1 CS on 18+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Clamp":{  
       "Type":"Water",
@@ -6044,7 +6410,8 @@
       "Range":"--",
       "Effect":"The user gains a +1 Bonus to Accuracy Rolls made to initiate Grapple Maneuvers, and +2 to Skill Checks made to initiate Grapple Maneuvers or gain Dominance. Whenever the user gains Dominance in a Grapple, the target of the Grapple loses a Tick of Hit Points.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Crabhammer":{  
       "Type":"Water",
@@ -6055,7 +6422,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Crabhammer is a Critical Hit on 18+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":18
    },
    "Dive":{  
       "Type":"Water",
@@ -6066,7 +6434,8 @@
       "Range":"Burst 1, Set Up, Full Action",
       "Effect":"Set-Up Effect: The user moves underwater and its turn ends. The user must be in water at least 10 meters deep to use Dive. While underwater, the user may not be targeted by Moves. Resolution Effect: The user may shift horizontally using their underwater speed, and then may shift straight up until reaching a target. The user then attacks with Dive, creating a Burst 1.",
       "Contest Type":"Beauty",
-      "Contest Effect":" Special Attention"
+      "Contest Effect":" Special Attention",
+      "Crits On":20
    },
    "Hydro Cannon":{  
       "Type":"Water",
@@ -6076,7 +6445,8 @@
       "Class":"Special",
       "Range":"Line 9, Smite, Exhaust",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Hydro Pump":{  
       "Type":"Water",
@@ -6087,7 +6457,8 @@
       "Range":"6, 1 Target, Push",
       "Effect":"The target is pushed away from the user 3 meters.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Muddy Water":{  
       "Type":"Water",
@@ -6098,7 +6469,8 @@
       "Range":"Close Blast 2",
       "Effect":"As a Shift Action, the user may Move to any open square in Muddy Water’s area of effect without provoking any Attacks of Opportunity. On 16+, the Accuracy of all targets is lowered by 1.",
       "Contest Type":"Tough",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Octazooka":{  
       "Type":"Water",
@@ -6109,7 +6481,8 @@
       "Range":"6,  1 Target",
       "Effect":"Octazooka lowers the target's Accuracy by -1 on an Even-Numbered Roll.",
       "Contest Type":"Tough",
-      "Contest Effect":"Incentives"
+      "Contest Effect":"Incentives",
+      "Crits On":20
    },
    "Origin Pulse":{  
       "Type":"Water",
@@ -6119,7 +6492,8 @@
       "Class":"Special",
       "Range":"Close Blast 3, Smite",
       "Contest Type":"Beauty",
-      "Contest Effect":"Desperation"
+      "Contest Effect":"Desperation",
+      "Crits On":20
    },
    "Rain Dance":{  
       "Type":"Water",
@@ -6128,7 +6502,7 @@
       "Range":"Field, Weather",
       "Effect":"The weather becomes Rainy for 5 rounds. While Rainy, Water-Type Attacks gain a +5 bonus to Damage Rolls, and Fire-Type Attacks suffer a -5 Damage penalty.",
       "Contest Type":"Tough",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Razor Shell":{  
       "Type":"Water",
@@ -6139,7 +6513,8 @@
       "Range":"Melee, 1 Target, Dash",
       "Effect":"Razor Shell lowers the target's Defense by -1 CS on an Even-Numbered Roll.",
       "Contest Type":"Cool",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Scald":{  
       "Type":"Water",
@@ -6150,7 +6525,8 @@
       "Range":"5, 1 Target",
       "Effect":"Scald Burns the target on 15+.",
       "Contest Type":"Smart",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Soak":{  
       "Type":"Water",
@@ -6160,7 +6536,7 @@
       "Range":"5, 1 Target",
       "Effect":"The target gains the Water type in addition to its other Types for 5 turns.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
    },
    "Surf":{  
       "Type":"Water",
@@ -6171,7 +6547,8 @@
       "Range":"Line 6",
       "Effect":"As a Shift Action, the user may Move to any open square in Surf ’s area of effect without provoking any Attacks of Opportunity.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Water Gun":{  
       "Type":"Water",
@@ -6182,7 +6559,8 @@
       "Range":"4, 1 Target",
       "Effect":"*Grants Fountain",
       "Contest Type":"Cute",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Water Pledge":{  
       "Type":"Water",
@@ -6193,7 +6571,8 @@
       "Range":"6, 1 Target, Pledge",
       "Effect":"If an ally uses Fire Pledge or Grass Pledge, you may use Water Pledge as Priority (Advanced) immediately after their turn to target the same foe. If used in conjunction with Fire Pledge, a Rainbow is created that lasts for 5 rounds. If used in conjunction with Grass Pledge, the target and all foes adjacent to the target are slowed and have their Speed reduced by 2 Combat Stages. Consult the Pledge keyword for additional details.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Water Pulse":{  
       "Type":"Water",
@@ -6204,7 +6583,8 @@
       "Range":"8, 1 Target, Aura",
       "Effect":"Water Pulse Confuses the target on 17+.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Exhausting Act"
+      "Contest Effect":"Exhausting Act",
+      "Crits On":20
    },
    "Water Shuriken":{  
       "Type":"Water",
@@ -6214,7 +6594,8 @@
       "Class":"Physical",
       "Range":" 6, 1 Target, Five Strike, Priority",
       "Contest Type":"Cool",
-      "Contest Effect":"Reliable"
+      "Contest Effect":"Reliable",
+      "Crits On":20
    },
    "Water Sport":{  
       "Type":"Water",
@@ -6223,7 +6604,7 @@
       "Range":"Burst 2, Coat",
       "Effect":"All targets in the burst, including the user, gain a Coat which grants them 1 Step of Resistance to Fire Type Moves. After a target has been hit by a damaging Fire Type Move, the coat is removed. *Grants Fountain",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
    },
    "Water Spout":{  
       "Type":"Water",
@@ -6234,7 +6615,8 @@
       "Range":"Burst 1*",
       "Effect":"For each 10% of HP the user is missing, Water Spout's Damage Base is reduced by -1. Water Spout creates a 1 meter burst, but also affects an area 10 meters tall straight up.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Seen Nothing Yet"
+      "Contest Effect":"Seen Nothing Yet",
+      "Crits On":20
    },
    "Waterfall":{  
       "Type":"Water",
@@ -6245,7 +6627,8 @@
       "Range":"Melee, 1 Target",
       "Effect":"Waterfall Flinches the target on 17+.",
       "Contest Type":"Tough",
-      "Contest Effect":"Steady Performance"
+      "Contest Effect":"Steady Performance",
+      "Crits On":20
    },
    "Whirlpool":{  
       "Type":"Water",
@@ -6256,7 +6639,8 @@
       "Range":"3, 1 Target",
       "Effect":"The target is put in a Vortex.",
       "Contest Type":"Beauty",
-      "Contest Effect":"Safe Option"
+      "Contest Effect":"Safe Option",
+      "Crits On":20
    },
    "Withdraw":{  
       "Type":"Water",
@@ -6265,7 +6649,8 @@
       "Range":"Self",
       "Effect":" The user becomes Withdrawn. While Withdrawn, the user becomes immune to Critical Hits and gain 15 Damage Reduction. However, while Withdrawn, the user cannot Shift, and may only use self-targeting Moves. The user may stop being Withdrawn as a Shift Action.",
       "Contest Type":"Cute",
-      "Contest Effect":"Sabotage"
+      "Contest Effect":"Sabotage",
+      "Crits On":20
    },
    "Hidden Power Bug":{  
       "Type":"Bug",
@@ -6275,7 +6660,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Dark":{  
       "Type":"Dark",
@@ -6285,7 +6671,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Dragon":{  
       "Type":"Dragon",
@@ -6295,7 +6682,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Electric":{  
       "Type":"Electric",
@@ -6305,7 +6693,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Fighting":{  
       "Type":"Fighting",
@@ -6315,7 +6704,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Fire":{  
       "Type":"Fire",
@@ -6325,7 +6715,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Flying":{  
       "Type":"Flying",
@@ -6335,7 +6726,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Ghost":{  
       "Type":"Ghost",
@@ -6345,7 +6737,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Grass":{  
       "Type":"Grass",
@@ -6355,7 +6748,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Ground":{  
       "Type":"Ground",
@@ -6365,7 +6759,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Ice":{  
       "Type":"Ice",
@@ -6375,7 +6770,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Poison":{  
       "Type":"Poison",
@@ -6385,7 +6781,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Psychic":{  
       "Type":"Psychic",
@@ -6395,7 +6792,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Rock":{  
       "Type":"Rock",
@@ -6405,7 +6803,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Steel":{  
       "Type":"Steel",
@@ -6415,7 +6814,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Water":{  
       "Type":"Water",
@@ -6425,7 +6825,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Hidden Power Fairy":{  
       "Type":"Fairy",
@@ -6435,7 +6836,8 @@
       "Class":"Special",
       "Range":"Burst 1",
       "Contest Type":"Smart",
-      "Contest Effect":" Catching Up"
+      "Contest Effect":" Catching Up",
+      "Crits On":20
    },
    "Struggle":{  
       "Type":"Normal",
@@ -6443,7 +6845,8 @@
       "AC":"4",
       "DB":"4",
       "Class":"Physical",
-      "Range":"Melee, 1 Target"
+      "Range":"Melee, 1 Target",
+      "Crits On":20
    },
    "Struggle+":{  
       "Type":"Normal",
@@ -6451,7 +6854,8 @@
       "AC":"3",
       "DB":"5",
       "Class":"Physical",
-      "Range":"Melee, 1 Target"
+      "Range":"Melee, 1 Target",
+      "Crits On":20
    },
    "Arcane Fury":{  
       "Type":"--",
@@ -6460,7 +6864,8 @@
       "DB":"3",
       "Class":"Special",
       "Range":"Cone 2",
-      "Effect":"Arcane Fury’s Targets become Vulnerable on 19+."
+      "Effect":"Arcane Fury’s Targets become Vulnerable on 19+.",
+      "Crits On":20
    },
    "Energy Blast":{  
       "Type":"--",
@@ -6469,7 +6874,8 @@
       "DB":"4",
       "Class":"Special",
       "Range":"WR, Blast 2",
-      "Effect":"You gain +1 Special Attack on 19+."
+      "Effect":"You gain +1 Special Attack on 19+.",
+      "Crits On":20
    },
    "Energy Sphere":{  
       "Type":"--",
@@ -6478,7 +6884,8 @@
       "DB":"4",
       "Class":"Special",
       "Range":"Burst 1",
-      "Effect":"You gain +1 Special Defense Combat Stage on 19+."
+      "Effect":"You gain +1 Special Defense Combat Stage on 19+.",
+      "Crits On":20
    },
    "Rending Spell":{  
       "Type":"--",
@@ -6487,7 +6894,8 @@
       "DB":"3",
       "Class":"Special",
       "Range":"WR, 1 Target",
-      "Effect":"The target loses a Tick of Hit Points on 16+."
+      "Effect":"The target loses a Tick of Hit Points on 16+.",
+      "Crits On":20
    },
    "Resonance Beam":{  
       "Type":"--",
@@ -6496,7 +6904,8 @@
       "DB":"4",
       "Class":"Special",
       "Range":"Line 4",
-      "Effect":"All targets have their Special Defense lowered by 1 Combat Stage on 20+. This Effect Range is extended by +1 for each foe targeted by this Move."
+      "Effect":"All targets have their Special Defense lowered by 1 Combat Stage on 20+. This Effect Range is extended by +1 for each foe targeted by this Move.",
+      "Crits On":20
    },
    "Secret Force":{  
       "Type":"--",
@@ -6505,7 +6914,8 @@
       "DB":"4",
       "Class":"Special",
       "Range":"Melee, 1 Target, Smite",
-      "Effect":"When calculating damage, the target subtracts their Defense from Secret Force’s damage instead of their Special Defense. Secret Force is still otherwise Special.\nLimitation: Melee Weapons Only"
+      "Effect":"When calculating damage, the target subtracts their Defense from Secret Force’s damage instead of their Special Defense. Secret Force is still otherwise Special.\nLimitation: Melee Weapons Only",
+      "Crits On":20
    },
    "Arcane Storm":{  
       "Type":"--",
@@ -6514,7 +6924,8 @@
       "DB":"6",
       "Class":"Special",
       "Range":"WR, Blast 3",
-      "Effect":"All targets of Arcane Storm are Slowed and Vulnerable for 1 Full Round.\nLimitation: Ranged Weapons only"
+      "Effect":"All targets of Arcane Storm are Slowed and Vulnerable for 1 Full Round.\nLimitation: Ranged Weapons only",
+      "Crits On":20
    },
    "Bane":{  
       "Type":"--",
@@ -6523,7 +6934,8 @@
       "DB":"4",
       "Class":"Special",
       "Range":"WR, 1 Target",
-      "Effect":"The target loses a Tick of Hit Points at the start of their next three turns and suffers a -2 penalty to all Save Checks on those turns."
+      "Effect":"The target loses a Tick of Hit Points at the start of their next three turns and suffers a -2 penalty to all Save Checks on those turns.",
+      "Crits On":20
    },
    "Cone of Force":{  
       "Type":"--",
@@ -6532,7 +6944,8 @@
       "DB":"6",
       "Class":"Special",
       "Range":"Cone 2, Push",
-      "Effect":"Cone of Force Pushes all targets 2 meters, and lowers their Evasion by -2 for 1 full round..\nLimitation: Melee Weapons Only"
+      "Effect":"Cone of Force Pushes all targets 2 meters, and lowers their Evasion by -2 for 1 full round..\nLimitation: Melee Weapons Only",
+      "Crits On":20
    },
    "Energy Vortex":{  
       "Type":"--",
@@ -6541,7 +6954,8 @@
       "DB":"2",
       "Class":"Special",
       "Range":"WR, 1 Target",
-      "Effect":"The target is put in a Vortex."
+      "Effect":"The target is put in a Vortex.",
+      "Crits On":20
    },
    "Magic Burst":{  
       "Type":"--",
@@ -6550,7 +6964,8 @@
       "DB":"6",
       "Class":"Special",
       "Range":"Burst 1, Friendly",
-      "Effect":"Foes hit by Magic Burst can’t make Attacks of Opportunity for 1 full round.\nLimitation: Melee Weapons Only"
+      "Effect":"Foes hit by Magic Burst can’t make Attacks of Opportunity for 1 full round.\nLimitation: Melee Weapons Only",
+      "Crits On":20
    },
    "Spirit Lance":{  
       "Type":"--",
@@ -6559,7 +6974,8 @@
       "DB":"6",
       "Class":"Special",
       "Range":"Line 6",
-      "Effect":"Spirit Lance deals +3 damage to all targets for each target beyond the first that it successfully hits."
+      "Effect":"Spirit Lance deals +3 damage to all targets for each target beyond the first that it successfully hits.",
+      "Crits On":20
    },
    "Backswing":{  
       "Type":"--",
@@ -6568,7 +6984,8 @@
       "DB":"7",
       "Class":"Physical",
       "Range":"Melee, 2 Targets",
-      "Effect":"Limitation: Large Melee Weapons Only"
+      "Effect":"Limitation: Large Melee Weapons Only",
+      "Crits On":20
    },
    "Bash!":{  
       "Type":"--",
@@ -6577,7 +6994,8 @@
       "DB":"7",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"Bash! lowers the target’s Initiative to 0 for 1 full round on 15+."
+      "Effect":"Bash! lowers the target’s Initiative to 0 for 1 full round on 15+.",
+      "Crits On":20
    },
    "Bullseye":{  
       "Type":"--",
@@ -6586,7 +7004,8 @@
       "DB":"6",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"Bullseye is a Critical Hit on 16+.\nLimitation: Ranged Weapons Only"
+      "Effect":"Bullseye is a Critical Hit on 16+.\nLimitation: Ranged Weapons Only",
+      "Crits On":16
    },
    "Cheap Shot":{  
       "Type":"--",
@@ -6595,7 +7014,8 @@
       "DB":"5",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"Cheap Shot cannot miss.\nLimitation: Small Melee and Short Ranged Weapons Only"
+      "Effect":"Cheap Shot cannot miss.\nLimitation: Small Melee and Short Ranged Weapons Only",
+      "Crits On":20
    },
    "Double Swipe":{  
       "Type":"--",
@@ -6603,7 +7023,8 @@
       "AC":"2",
       "DB":"4",
       "Class":"Physical",
-      "Range":"WR, 2 Targets; or WR, 1 Target, Double Strike"
+      "Range":"WR, 2 Targets; or WR, 1 Target, Double Strike",
+      "Crits On":20
    },
    "Pierce!":{  
       "Type":"--",
@@ -6612,7 +7033,8 @@
       "DB":"7",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"Pierce deals an additional +10 damage against targets with Damage Reduction."
+      "Effect":"Pierce deals an additional +10 damage against targets with Damage Reduction.",
+      "Crits On":20
    },
    "Salvo":{  
       "Type":"--",
@@ -6621,14 +7043,15 @@
       "DB":"6",
       "Class":"Physical",
       "Range":"WR, Blast 2",
-      "Effect":"Limitation: Ranged Weapons Only"
+      "Effect":"Limitation: Ranged Weapons Only",
+      "Crits On":20
    },
    "Take Aim":{  
       "Type":"--",
       "Freq":"EOT",
       "Class":"Status",
       "Range":"Self",
-      "Effect":"Raise the user’s Accuracy by +1. If the user performs an Weapon Move on their next turn that deals damage, add its Damage Dice Roll an extra time to the damage."
+      "Effect":"Raise the user’s Accuracy by +1. If the user performs an Weapon Move on their next turn that deals damage, add its Damage Dice Roll an extra time to the damage.",
    },
    "Wear Down":{  
       "Type":"--",
@@ -6637,7 +7060,8 @@
       "DB":"5",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"Wear Down lowers the target’s Defense by 1 Combat Stage on Even-Numbered Rolls."
+      "Effect":"Wear Down lowers the target’s Defense by 1 Combat Stage on Even-Numbered Rolls.",
+      "Crits On":20
    },
    "Wounding Strike":{  
       "Type":"--",
@@ -6646,7 +7070,8 @@
       "DB":"6",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"The target loses a Tick of Hit Points."
+      "Effect":"The target loses a Tick of Hit Points.",
+      "Crits On":20
    },
    "Bleed!":{  
       "Type":"--",
@@ -6655,7 +7080,8 @@
       "DB":"9",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"The target loses a Tick of Hit Points at the start of their next three turns."
+      "Effect":"The target loses a Tick of Hit Points at the start of their next three turns.",
+      "Crits On":20
    },
    "Deadly Strike":{  
       "Type":"--",
@@ -6664,7 +7090,8 @@
       "DB":"6",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"If Deadly Strike Hits, it is a Critical Hit.\nLimitation: Not usable by Large Melee Weapons."
+      "Effect":"If Deadly Strike Hits, it is a Critical Hit.\nLimitation: Not usable by Large Melee Weapons.",
+      "Crits On":0
    },
    "Furious Strikes":{  
       "Type":"--",
@@ -6673,7 +7100,8 @@
       "DB":"3",
       "Class":"Physical",
       "Range":"WR, 1 Target, Five Strike",
-      "Effect":"For each hit rolled on your Five Strike roll, the target of the attack has their Evasion reduced by 1 for one full round.\nLimitation: Melee or Short Ranged Weapons Only"
+      "Effect":"For each hit rolled on your Five Strike roll, the target of the attack has their Evasion reduced by 1 for one full round.\nLimitation: Melee or Short Ranged Weapons Only",
+      "Crits On":20
    },
    "Gouge":{  
       "Type":"--",
@@ -6682,7 +7110,8 @@
       "DB":"5",
       "Class":"Physical",
       "Range":"WR, 1 Target, Double Strike",
-      "Effect":"If both hits of Gouge successfully hit the target, the target gains an Injury.\nLimitation: Small Melee and Short Ranged Weapons Only"
+      "Effect":"If both hits of Gouge successfully hit the target, the target gains an Injury.\nLimitation: Small Melee and Short Ranged Weapons Only",
+      "Crits On":20
    },
    "Maul":{  
       "Type":"--",
@@ -6691,7 +7120,8 @@
       "DB":"5",
       "Class":"Physical",
       "Range":"1 Target, Melee",
-      "Effect":"The target is Flinched.\nLimitation: Melee Weapons Only"
+      "Effect":"The target is Flinched.\nLimitation: Melee Weapons Only",
+      "Crits On":20
    },
    "Riposte":{  
       "Type":"--",
@@ -6700,7 +7130,8 @@
       "DB":"12",
       "Class":"Physical",
       "Range":"WR, 1 Target, Reaction, Trigger",
-      "Effect":"Trigger: Your Target misses you with a melee Attack.\nLimitations: Melee or Short-Ranged Weapons Only"
+      "Effect":"Trigger: Your Target misses you with a melee Attack.\nLimitations: Melee or Short-Ranged Weapons Only",
+      "Crits On":20
    },
    "Slice":{  
       "Type":"--",
@@ -6709,7 +7140,8 @@
       "DB":"10",
       "Class":"Physical",
       "Range":"Melee, Pass",
-      "Effect":"Limitation: Melee Weapons Only"
+      "Effect":"Limitation: Melee Weapons Only",
+      "Crits On":20
    },
    "Sweeping Strike":{  
       "Type":"--",
@@ -6718,7 +7150,8 @@
       "DB":"9",
       "Class":"Physical",
       "Range":"WR, 1 Target",
-      "Effect":"You may attempt a Trip Maneuver against the target as a free action.\nLimitation: Short-Range Weapons or Weapons with the Reach Quality Only"
+      "Effect":"You may attempt a Trip Maneuver against the target as a free action.\nLimitation: Short-Range Weapons or Weapons with the Reach Quality Only",
+      "Crits On":20
    },
    "Titanic Slam":{  
       "Type":"--",
@@ -6727,7 +7160,8 @@
       "DB":"11",
       "Class":"Physical",
       "Range":"1 Target, Melee",
-      "Effect":"On Even-Numbered Rolls, the target is Slowed for one full round.\nLimitation: Melee Weapons Only"
+      "Effect":"On Even-Numbered Rolls, the target is Slowed for one full round.\nLimitation: Melee Weapons Only",
+      "Crits On":20
    },
    "Triple Threat":{  
       "Type":"--",
@@ -6736,6 +7170,7 @@
       "DB":"7",
       "Class":"Physical",
       "Range":"WR, 3 Targets",
-      "Effect":"Limitation: Large Melee Weapons and Long-Range Weapons Only"
+      "Effect":"Limitation: Large Melee Weapons and Long-Range Weapons Only",
+      "Crits On":20
    }
 }


### PR DESCRIPTION
Added a "Crits On" attribute to all non-status moves. This represents the minimum d20 value at which the move counts as a crit, assuming, of course, I've correctly implemented it.